### PR TITLE
add azure_iot.h

### DIFF
--- a/source/include/azure_iot.h
+++ b/source/include/azure_iot.h
@@ -128,9 +128,10 @@ AzureIoTResult_t AzureIoT_MessagePropertiesFind( AzureIoTMessageProperties_t * p
  * @param[in] ulMessageSize The length of \p pucMessage.
  * @param[in] pucBuffer An intermediary buffer to put the base64 decoded key.
  * @param[in] ulBufferLength The length of \p pucBuffer.
- * @param[out] ppucOutput The buffer into which the resulting HMAC256 hashed, base64 encoded message will
+ * @param[out] pucOutput The buffer into which the resulting HMAC256 hashed, base64 encoded message will
  * be placed.
- * @param[out] pulOutputLength The output length of \p ppucOutput.
+ * @param[in] ulOutputSize Size of \p pucOutput.
+ * @param[out] pulOutputLength The output length of \p pucOutput.
  * @return An #AzureIoTResult_t with the result of the operation.
  */
 AzureIoTResult_t AzureIoT_Base64HMACCalculate( AzureIoTGetHMACFunc_t xAzureIoTHMACFunction,
@@ -140,7 +141,8 @@ AzureIoTResult_t AzureIoT_Base64HMACCalculate( AzureIoTGetHMACFunc_t xAzureIoTHM
                                                uint32_t ulMessageSize,
                                                uint8_t * pucBuffer,
                                                uint32_t ulBufferLength,
-                                               uint8_t ** ppucOutput,
+                                               uint8_t * pucOutput,
+                                               uint32_t ulOutputSize,
                                                uint32_t * pulOutputLength );
 
 #endif /* AZURE_IOT_H */

--- a/source/include/azure_iot.h
+++ b/source/include/azure_iot.h
@@ -34,11 +34,11 @@
 
 typedef enum AzureIoTResult
 {
-    eAzureIoTSuccess = 0,        /**< Success. */
-    eAzureIoTInvalidArgument,    /**< Input argument does not comply with the expected range of values. */
-    eAzureIoTStatusOutOfMemory,  /**< The system is out of memory. */
-    eAzureIoTStatusItemNotFound, /**< The item was not found. */
-    eAzureIoTFailed,             /**< There was a failure. */
+    eAzureIoTSuccess = 0,     /**< Success. */
+    eAzureIoTInvalidArgument, /**< Input argument does not comply with the expected range of values. */
+    eAzureIoTOutOfMemory,     /**< The system is out of memory. */
+    eAzureIoTItemNotFound,    /**< The item was not found. */
+    eAzureIoTFailed,          /**< There was a failure. */
 } AzureIoTResult_t;
 
 /**
@@ -61,16 +61,16 @@ typedef uint32_t ( * AzureIoTGetHMACFunc_t )( const uint8_t * pucKey,
                                               uint32_t ulDataLength,
                                               uint8_t * pucOutput,
                                               uint32_t ulOutputLength,
-                                              uint32_t * pucBytesCopied );
+                                              uint32_t * pulBytesCopied );
 
 /**
- * @brief Initialize Azure IoT
+ * @brief Initialize Azure IoT middleware.
  *
  */
 AzureIoTResult_t AzureIoT_Init();
 
 /**
- * @brief Deinitialize Azure IoT
+ * @brief Deinitialize Azure IoT middleware.
  *
  */
 void AzureIoT_Deinit();
@@ -90,7 +90,7 @@ AzureIoTResult_t AzureIoT_MessagePropertiesInit( AzureIoTMessageProperties_t * p
                                                  uint32_t ulBufferLength );
 
 /**
- * @brief Append a property name and value.
+ * @brief Append a property name and value to a message.
  *
  * @param[in] pxMessageProperties The #AzureIoTMessageProperties_t* to use for the operation.
  * @param[in] pucName The name of the property to append.
@@ -111,7 +111,7 @@ AzureIoTResult_t AzureIoT_MessagePropertiesAppend( AzureIoTMessageProperties_t *
  * @param[in] pxMessageProperties The #AzureIoTMessageProperties_t* to use for the operation.
  * @param[in] pucName The name of the property to find.
  * @param[in] nameLength Length of the property name.
- * @param[out] ppucOutValue The output pointer to the value.
+ * @param[out] ppucOutValue The output pointer to the property value.
  * @param[out] pulOutValueLength The length of \p ppucOutValue.
  * @return An #AzureIoTResult_t with the result of the operation.
  */
@@ -124,12 +124,12 @@ AzureIoTResult_t AzureIoT_MessagePropertiesFind( AzureIoTMessageProperties_t * p
 /**
  * @brief As part of symmetric key authentication, HMAC256 a buffer of bytes and base64 encode the result.
  *
- * @note This is used within Azure IoT Hub and Device Provisioning APIs should a symmetric key be set.
+ * @note This is used within Azure IoT Hub and Device Provisioning APIs if a symmetric key is set.
  *
  * @param[in] xAzureIoTHMACFunction The #AzureIoTGetHMACFunc_t function to use for HMAC256 hashing.
  * @param[in] pucKey A pointer to the base64 encoded key.
  * @param[in] ulKeySize The length of the \p pucKey.
- * @param[in] pucMessage A pointer to the message to be hashed.
+ * @param[in] pucMessage A pointer to the blob to be hashed.
  * @param[in] ulMessageSize The length of \p pucMessage.
  * @param[in] pucBuffer An intermediary buffer to put the base64 decoded key.
  * @param[in] ulBufferLength The length of \p pucBuffer.

--- a/source/include/azure_iot.h
+++ b/source/include/azure_iot.h
@@ -16,10 +16,10 @@
 #ifndef AZURE_IOT_H
 #define AZURE_IOT_H
 
-/* AZURE_IOT_DO_NOT_USE_CUSTOM_CONFIG allows building the azure iot library
+/* AZURE_IOT_CUSTOM_CONFIG allows building the azure iot library
  * without a custom config. If a custom config is provided, the
- * AZURE_IOT_DO_NOT_USE_CUSTOM_CONFIG macro should not be defined. */
-#ifndef AZURE_IOT_DO_NOT_USE_CUSTOM_CONFIG
+ * AZURE_IOT_CUSTOM_CONFIG macro should not be defined. */
+#ifdef AZURE_IOT_CUSTOM_CONFIG
     /* Include custom config file before other headers. */
     #include "azure_iot_config.h"
 #endif
@@ -31,6 +31,7 @@
 #include "FreeRTOS.h"
 
 #include "azure/az_iot.h"
+#include "azure/internal/az_iot_internal.h"
 
 typedef enum AzureIoTResult
 {
@@ -66,17 +67,30 @@ typedef uint32_t ( * AzureIoTGetHMACFunc_t )( const uint8_t * pucKey,
 /**
  * @brief Initialize Azure IoT middleware.
  *
+ * @note This should be called once per process.
+ *
  */
 AzureIoTResult_t AzureIoT_Init();
 
 /**
  * @brief Deinitialize Azure IoT middleware.
  *
+ * @note This should be called once per process.
+ *
  */
 void AzureIoT_Deinit();
 
 /**
  * @brief Initialize the message properties.
+ *
+ * @note The properties init API will not encode properties. In order to support
+ *       the following characters, they must be percent-encoded (RFC3986) as follows:
+ *         - `/` : `%2F`
+ *         - `%` : `%25`
+ *         - `#` : `%23`
+ *         - `&` : `%26`
+ *       Only these characters would have to be encoded. If you would like to avoid the need to
+ *       encode the names/values, avoid using these characters in names and values.
  *
  * @param[out] pxMessageProperties The #AzureIoTMessageProperties_t* to use for the operation.
  * @param[out] pucBuffer The pointer to the buffer.
@@ -86,11 +100,20 @@ void AzureIoT_Deinit();
  */
 AzureIoTResult_t AzureIoT_MessagePropertiesInit( AzureIoTMessageProperties_t * pxMessageProperties,
                                                  uint8_t * pucBuffer,
-                                                 uint32_t ulWrittenLength,
+                                                 uint32_t ulAlreadyWrittenLength,
                                                  uint32_t ulBufferLength );
 
 /**
  * @brief Append a property name and value to a message.
+ *
+ * @note The properties init API will not encode properties. In order to support
+ *       the following characters, they must be percent-encoded (RFC3986) as follows:
+ *         - `/` : `%2F`
+ *         - `%` : `%25`
+ *         - `#` : `%23`
+ *         - `&` : `%26`
+ *       Only these characters would have to be encoded. If you would like to avoid the need to
+ *       encode the names/values, avoid using these characters in names and values.
  *
  * @param[in] pxMessageProperties The #AzureIoTMessageProperties_t* to use for the operation.
  * @param[in] pucName The name of the property to append.

--- a/source/include/azure_iot.h
+++ b/source/include/azure_iot.h
@@ -76,7 +76,7 @@ AzureIoTResult_t AzureIoT_Init();
 void AzureIoT_Deinit();
 
 /**
- * @brief Initialize
+ * @brief Initialize the message properties.
  *
  * @param[out] pxMessageProperties The #AzureIoTMessageProperties_t* to use for the operation.
  * @param[out] pucBuffer The pointer to the buffer.
@@ -90,7 +90,7 @@ AzureIoTResult_t AzureIoT_MessagePropertiesInit( AzureIoTMessageProperties_t * p
                                                  uint32_t ulBufferLength );
 
 /**
- * @brief Append a property name and value
+ * @brief Append a property name and value.
  *
  * @param[in] pxMessageProperties The #AzureIoTMessageProperties_t* to use for the operation.
  * @param[in] pucName The name of the property to append.

--- a/source/include/azure_iot.h
+++ b/source/include/azure_iot.h
@@ -40,7 +40,7 @@ typedef enum AzureIoTResult
  * @brief The bag of properties associated with a message.
  *
  */
-typedef struct AzureIoTHubClientMessageProperties
+typedef struct AzureIoTMessageProperties
 {
     struct
     {
@@ -73,10 +73,10 @@ void AzureIoT_Deinit();
 /**
  * @brief Initialize
  *
- * @param pxMessageProperties The #AzureIoTMessageProperties_t* to use for the operation.
- * @param pucBuffer The pointer to the buffer.
- * @param ulWrittenLength The length of the properties already written (if applicable).
- * @param ulBufferLength The length of \p pucBuffer.
+ * @param[out] pxMessageProperties The #AzureIoTMessageProperties_t* to use for the operation.
+ * @param[out] pucBuffer The pointer to the buffer.
+ * @param[in] ulWrittenLength The length of the properties already written (if applicable).
+ * @param[in] ulBufferLength The length of \p pucBuffer.
  * @return An #AzureIoTResult_t with the result of the operation.
  */
 AzureIoTResult_t AzureIoT_MessagePropertiesInit( AzureIoTMessageProperties_t * pxMessageProperties,
@@ -87,11 +87,11 @@ AzureIoTResult_t AzureIoT_MessagePropertiesInit( AzureIoTMessageProperties_t * p
 /**
  * @brief Append a property name and value
  *
- * @param pxMessageProperties The #AzureIoTMessageProperties_t* to use for the operation.
- * @param pucName The name of the property to append.
- * @param ulNameLength The length of \p pucName.
- * @param pucValue The value of the property to append.
- * @param ulValueLength The length of \p pucValue.
+ * @param[in] pxMessageProperties The #AzureIoTMessageProperties_t* to use for the operation.
+ * @param[in] pucName The name of the property to append.
+ * @param[in] ulNameLength The length of \p pucName.
+ * @param[in] pucValue The value of the property to append.
+ * @param[in] ulValueLength The length of \p pucValue.
  * @return An #AzureIoTResult_t with the result of the operation.
  */
 AzureIoTResult_t AzureIoT_MessagePropertiesAppend( AzureIoTMessageProperties_t * pxMessageProperties,
@@ -103,11 +103,11 @@ AzureIoTResult_t AzureIoT_MessagePropertiesAppend( AzureIoTMessageProperties_t *
 /**
  * @brief Find a property in the message property bag.
  *
- * @param pxMessageProperties The #AzureIoTMessageProperties_t* to use for the operation.
- * @param pucName The name of the property to find.
- * @param nameLength Length of the property name.
- * @param ppucOutValue The output pointer to the value.
- * @param pulOutValueLength The length of \p ppucOutValue.
+ * @param[in] pxMessageProperties The #AzureIoTMessageProperties_t* to use for the operation.
+ * @param[in] pucName The name of the property to find.
+ * @param[in] nameLength Length of the property name.
+ * @param[out] ppucOutValue The output pointer to the value.
+ * @param[out] pulOutValueLength The length of \p ppucOutValue.
  * @return An #AzureIoTResult_t with the result of the operation.
  */
 AzureIoTResult_t AzureIoT_MessagePropertiesFind( AzureIoTMessageProperties_t * pxMessageProperties,
@@ -121,16 +121,16 @@ AzureIoTResult_t AzureIoT_MessagePropertiesFind( AzureIoTMessageProperties_t * p
  *
  * @note This is used within Azure IoT Hub and Device Provisioning APIs should a symmetric key be set.
  *
- * @param xAzureIoTHMACFunction The #AzureIoTGetHMACFunc_t function to use for HMAC256 hashing.
- * @param pucKey A pointer to the base64 encoded key.
- * @param ulKeySize The length of the \p pucKey.
- * @param pucMessage A pointer to the message to be hashed.
- * @param ulMessageSize The length of \p pucMessage.
- * @param pucBuffer An intermediary buffer to put the base64 decoded key.
- * @param ulBufferLength The length of \p pucBuffer.
- * @param ppucOutput The buffer into which the resulting HMAC256 hashed, base64 encoded message will
+ * @param[in] xAzureIoTHMACFunction The #AzureIoTGetHMACFunc_t function to use for HMAC256 hashing.
+ * @param[in] pucKey A pointer to the base64 encoded key.
+ * @param[in] ulKeySize The length of the \p pucKey.
+ * @param[in] pucMessage A pointer to the message to be hashed.
+ * @param[in] ulMessageSize The length of \p pucMessage.
+ * @param[in] pucBuffer An intermediary buffer to put the base64 decoded key.
+ * @param[in] ulBufferLength The length of \p pucBuffer.
+ * @param[out] ppucOutput The buffer into which the resulting HMAC256 hashed, base64 encoded message will
  * be placed.
- * @param pulOutputLength The output length of \p ppucOutput.
+ * @param[out] pulOutputLength The output length of \p ppucOutput.
  * @return An #AzureIoTResult_t with the result of the operation.
  */
 AzureIoTResult_t AzureIoT_Base64HMACCalculate( AzureIoTGetHMACFunc_t xAzureIoTHMACFunction,

--- a/source/include/azure_iot.h
+++ b/source/include/azure_iot.h
@@ -5,6 +5,11 @@
  * @file azure_iot.h
  *
  * @brief Azure IoT FreeRTOS middleware common APIs and structs
+ * 
+ * @note You MUST NOT use any symbols (macros, functions, structures, enums, etc.) 
+ * prefixed with an underscore ('_') directly in your application code. These symbols
+ * are part of Azure SDK's internal implementation; we do not document these symbols
+ * and they are subject to change in future versions of the SDK which would break your code.
  *
  */
 

--- a/source/include/azure_iot.h
+++ b/source/include/azure_iot.h
@@ -5,8 +5,8 @@
  * @file azure_iot.h
  *
  * @brief Azure IoT FreeRTOS middleware common APIs and structs
- * 
- * @note You MUST NOT use any symbols (macros, functions, structures, enums, etc.) 
+ *
+ * @note You MUST NOT use any symbols (macros, functions, structures, enums, etc.)
  * prefixed with an underscore ('_') directly in your application code. These symbols
  * are part of Azure SDK's internal implementation; we do not document these symbols
  * and they are subject to change in future versions of the SDK which would break your code.
@@ -36,7 +36,7 @@ typedef enum AzureIoTResult
 {
     eAzureIoTSuccess = 0,        /**< Success. */
     eAzureIoTInvalidArgument,    /**< Input argument does not comply with the expected range of values. */
-    eAzureIoTStatusOom,          /**< The system is out of memory. */
+    eAzureIoTStatusOutOfMemory,  /**< The system is out of memory. */
     eAzureIoTStatusItemNotFound, /**< The item was not found. */
     eAzureIoTFailed,             /**< There was a failure. */
 } AzureIoTResult_t;
@@ -100,9 +100,9 @@ AzureIoTResult_t AzureIoT_MessagePropertiesInit( AzureIoTMessageProperties_t * p
  * @return An #AzureIoTResult_t with the result of the operation.
  */
 AzureIoTResult_t AzureIoT_MessagePropertiesAppend( AzureIoTMessageProperties_t * pxMessageProperties,
-                                                   uint8_t * pucName,
+                                                   const uint8_t * pucName,
                                                    uint32_t ulNameLength,
-                                                   uint8_t * pucValue,
+                                                   const uint8_t * pucValue,
                                                    uint32_t ulValueLength );
 
 /**
@@ -116,9 +116,9 @@ AzureIoTResult_t AzureIoT_MessagePropertiesAppend( AzureIoTMessageProperties_t *
  * @return An #AzureIoTResult_t with the result of the operation.
  */
 AzureIoTResult_t AzureIoT_MessagePropertiesFind( AzureIoTMessageProperties_t * pxMessageProperties,
-                                                 uint8_t * pucName,
+                                                 const uint8_t * pucName,
                                                  uint32_t ulNameLength,
-                                                 uint8_t ** ppucOutValue,
+                                                 const uint8_t ** ppucOutValue,
                                                  uint32_t * pulOutValueLength );
 
 /**

--- a/source/include/azure_iot.h
+++ b/source/include/azure_iot.h
@@ -1,0 +1,146 @@
+/* Copyright (c) Microsoft Corporation. All rights reserved. */
+/* SPDX-License-Identifier: MIT */
+
+/**
+ * @file azure_iot.h
+ *
+ * @brief Azure IoT FreeRTOS middleware common APIs and structs
+ *
+ */
+
+#ifndef AZURE_IOT_H
+#define AZURE_IOT_H
+
+/* AZURE_IOT_DO_NOT_USE_CUSTOM_CONFIG allows building the azure iot library
+ * without a custom config. If a custom config is provided, the
+ * AZURE_IOT_DO_NOT_USE_CUSTOM_CONFIG macro should not be defined. */
+#ifndef AZURE_IOT_DO_NOT_USE_CUSTOM_CONFIG
+    /* Include custom config file before other headers. */
+    #include "azure_iot_config.h"
+#endif
+
+/* Include config defaults header to get default values of configs not
+ * defined in azure_iot_mqtt_config.h file. */
+#include "azure_iot_config_defaults.h"
+
+#include "FreeRTOS.h"
+
+#include "azure/az_iot.h"
+
+typedef enum AzureIoTResult
+{
+    eAzureIoTSuccess = 0,        /**< Success. */
+    eAzureIoTInvalidArgument,    /**< Input argument does not comply with the expected range of values. */
+    eAzureIoTStatusOom,          /**< The system is out of memory. */
+    eAzureIoTStatusItemNotFound, /**< The item was not found. */
+    eAzureIoTFailed,             /**< There was a failure. */
+} AzureIoTResult_t;
+
+/**
+ * @brief The bag of properties associated with a message.
+ *
+ */
+typedef struct AzureIoTHubClientMessageProperties
+{
+    struct
+    {
+        az_iot_message_properties xProperties;
+    } _internal;
+} AzureIoTMessageProperties_t;
+
+typedef uint64_t ( * AzureIoTGetCurrentTimeFunc_t )( void );
+
+typedef uint32_t ( * AzureIoTGetHMACFunc_t )( const uint8_t * pucKey,
+                                              uint32_t ulKeyLength,
+                                              const uint8_t * pucData,
+                                              uint32_t ulDataLength,
+                                              uint8_t * pucOutput,
+                                              uint32_t ulOutputLength,
+                                              uint32_t * pucBytesCopied );
+
+/**
+ * @brief Initialize Azure IoT
+ *
+ */
+AzureIoTResult_t AzureIoT_Init();
+
+/**
+ * @brief Deinitialize Azure IoT
+ *
+ */
+void AzureIoT_Deinit();
+
+/**
+ * @brief Initialize
+ *
+ * @param pxMessageProperties The #AzureIoTMessageProperties_t* to use for the operation.
+ * @param pucBuffer The pointer to the buffer.
+ * @param ulWrittenLength The length of the properties already written (if applicable).
+ * @param ulBufferLength The length of \p pucBuffer.
+ * @return An #AzureIoTResult_t with the result of the operation.
+ */
+AzureIoTResult_t AzureIoT_MessagePropertiesInit( AzureIoTMessageProperties_t * pxMessageProperties,
+                                                 uint8_t * pucBuffer,
+                                                 uint32_t ulWrittenLength,
+                                                 uint32_t ulBufferLength );
+
+/**
+ * @brief Append a property name and value
+ *
+ * @param pxMessageProperties The #AzureIoTMessageProperties_t* to use for the operation.
+ * @param pucName The name of the property to append.
+ * @param ulNameLength The length of \p pucName.
+ * @param pucValue The value of the property to append.
+ * @param ulValueLength The length of \p pucValue.
+ * @return An #AzureIoTResult_t with the result of the operation.
+ */
+AzureIoTResult_t AzureIoT_MessagePropertiesAppend( AzureIoTMessageProperties_t * pxMessageProperties,
+                                                   uint8_t * pucName,
+                                                   uint32_t ulNameLength,
+                                                   uint8_t * pucValue,
+                                                   uint32_t ulValueLength );
+
+/**
+ * @brief Find a property in the message property bag.
+ *
+ * @param pxMessageProperties The #AzureIoTMessageProperties_t* to use for the operation.
+ * @param pucName The name of the property to find.
+ * @param nameLength Length of the property name.
+ * @param ppucOutValue The output pointer to the value.
+ * @param pulOutValueLength The length of \p ppucOutValue.
+ * @return An #AzureIoTResult_t with the result of the operation.
+ */
+AzureIoTResult_t AzureIoT_MessagePropertiesFind( AzureIoTMessageProperties_t * pxMessageProperties,
+                                                 uint8_t * pucName,
+                                                 uint32_t ulNameLength,
+                                                 uint8_t ** ppucOutValue,
+                                                 uint32_t * pulOutValueLength );
+
+/**
+ * @brief As part of symmetric key authentication, HMAC256 a buffer of bytes and base64 encode the result.
+ *
+ * @note This is used within Azure IoT Hub and Device Provisioning APIs should a symmetric key be set.
+ *
+ * @param xAzureIoTHMACFunction The #AzureIoTGetHMACFunc_t function to use for HMAC256 hashing.
+ * @param pucKey A pointer to the base64 encoded key.
+ * @param ulKeySize The length of the \p pucKey.
+ * @param pucMessage A pointer to the message to be hashed.
+ * @param ulMessageSize The length of \p pucMessage.
+ * @param pucBuffer An intermediary buffer to put the base64 decoded key.
+ * @param ulBufferLength The length of \p pucBuffer.
+ * @param ppucOutput The buffer into which the resulting HMAC256 hashed, base64 encoded message will
+ * be placed.
+ * @param pulOutputLength The output length of \p ppucOutput.
+ * @return An #AzureIoTResult_t with the result of the operation.
+ */
+AzureIoTResult_t AzureIoT_Base64HMACCalculate( AzureIoTGetHMACFunc_t xAzureIoTHMACFunction,
+                                               const uint8_t * pucKey,
+                                               uint32_t ulKeySize,
+                                               const uint8_t * pucMessage,
+                                               uint32_t ulMessageSize,
+                                               uint8_t * pucBuffer,
+                                               uint32_t ulBufferLength,
+                                               uint8_t ** ppucOutput,
+                                               uint32_t * pulOutputLength );
+
+#endif /* AZURE_IOT_H */


### PR DESCRIPTION
Noteable changes from the `sdk_spike` branch:
- Changed the result from `AzureIoTError_t` to `AzureIoTResult_t`.
- Naming updates for some parameters to fit the FreeRTOS guidelines.
- Added a brief description for the file doxygen header.
- Updated enum values from uppercase snake case to Pascal prefixed with `e`.
    - ex: `AZURE_IOT_SUCCESS ` to `eAzureIoTSuccess`