### PR TITLE
Fix argument type casting on log statements

### DIFF
--- a/source/azure_iot_hub_client.c
+++ b/source/azure_iot_hub_client.c
@@ -221,7 +221,7 @@ static uint32_t prvAzureIoTHubClientC2DProcess( AzureIoTHubClientReceiveContext_
                       xMQTTPublishInfo->usTopicNameLength,
                       xMQTTPublishInfo->pcTopicName,
                       xMQTTPublishInfo->xPayloadLength,
-                      xMQTTPublishInfo->pvPayload ) );
+                      ( const char * ) xMQTTPublishInfo->pvPayload ) );
 
         if( pxContext->_internal.callbacks.xCloudToDeviceMessageCallback )
         {
@@ -272,7 +272,7 @@ static uint32_t prvAzureIoTHubClientCommandProcess( AzureIoTHubClientReceiveCont
                       xMQTTPublishInfo->usTopicNameLength,
                       xMQTTPublishInfo->pcTopicName,
                       xMQTTPublishInfo->xPayloadLength,
-                      xMQTTPublishInfo->pvPayload ) );
+                      ( const char * ) xMQTTPublishInfo->pvPayload ) );
 
         if( pxContext->_internal.callbacks.xCommandCallback )
         {
@@ -328,7 +328,7 @@ static uint32_t prvAzureIoTHubClientPropertiesProcess( AzureIoTHubClientReceiveC
                       xMQTTPublishInfo->usTopicNameLength,
                       xMQTTPublishInfo->pcTopicName,
                       xMQTTPublishInfo->xPayloadLength,
-                      xMQTTPublishInfo->pvPayload ) );
+                      ( const char * ) xMQTTPublishInfo->pvPayload ) );
 
         xResult = eAzureIoTSuccess;
 


### PR DESCRIPTION
Logging functions often depend on format translation done similar to
sprintf. In such case, the void* arguments passed need to be cast to
const char* so the format provided matches the args.