### PR TITLE
Add ESPRESSIF ESP32 to the list of samples on readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This repo contains the Azure IoT middleware for FreeRTOS libraries and has depen
 - STM32L4+
 - STM32H745
 - NXP RT1060
+- ESPRESSIF ESP32
 - Linux
 - Windows
 


### PR DESCRIPTION
This PR replaces https://github.com/Azure/azure-iot-middleware-freertos/pull/177