### PR TITLE
DPS state machine fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,7 +61,7 @@ dkms.conf
 *.user
 
 # CMake build directory
-/build
+build/
 
 # Doxygen build directory
 /doc

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Azure IoT middleware for FreeRTOS 
+# Azure IoT Middleware for FreeRTOS 
 
 [![Linux CI Tests](https://github.com/Azure/azure-iot-middleware-freertos/actions/workflows/ci_tests_linux.yml/badge.svg?branch=main)](https://github.com/Azure/azure-iot-middleware-freertos/actions/workflows/ci_tests_linux.yml)
 

--- a/docs/azure_iot_c_sdk_port.md
+++ b/docs/azure_iot_c_sdk_port.md
@@ -111,9 +111,9 @@ IoTHubDeviceClient_LL_SendEventAsync(device_ll_handle, message_handle, send_conf
 
 ```c
 /* Create a bag of properties for the telemetry */
-xResult = AzureIoT_MessagePropertiesInit( &xPropertyBag, ucPropertyBuffer, 0, sizeof( xPropertyBag ) );
+xResult = AzureIoTMessage_PropertiesInit( &xPropertyBag, ucPropertyBuffer, 0, sizeof( xPropertyBag ) );
 
-xResult = AzureIoT_MessagePropertiesAppend( &xPropertyBag, ( uint8_t * ) "name", sizeof( "name" ) - 1,
+xResult = AzureIoTMessage_PropertiesAppend( &xPropertyBag, ( uint8_t * ) "name", sizeof( "name" ) - 1,
                                             ( uint8_t * ) "value", sizeof( "value" ) - 1 );
 
 xResult = AzureIoTHubClient_SendTelemetry( &xAzureIoTHubClient,

--- a/source/azure_iot_provisioning_client.c
+++ b/source/azure_iot_provisioning_client.c
@@ -366,7 +366,7 @@ static void prvProvClientParseResponse( AzureIoTProvisioningClient_t * pxAzurePr
                      pxAzureProvClient->_internal.ulWorkflowState ) );
         return;
     }
-    
+
     if( ( pxAzureProvClient->_internal.usLastResponseTopicLength == 0 ) ||
         ( pxAzureProvClient->_internal.xLastResponsePayloadLength == 0 ) )
     {
@@ -377,9 +377,9 @@ static void prvProvClientParseResponse( AzureIoTProvisioningClient_t * pxAzurePr
 
     xCoreResult =
         az_iot_provisioning_client_parse_received_topic_and_payload( &pxAzureProvClient->_internal.xProvisioningClientCore,
-                                                                        xTopic, xPayload, &pxAzureProvClient->_internal.xRegisterResponse );
+                                                                     xTopic, xPayload, &pxAzureProvClient->_internal.xRegisterResponse );
 
-    if ( xCoreResult == AZ_ERROR_IOT_TOPIC_NO_MATCH)
+    if( xCoreResult == AZ_ERROR_IOT_TOPIC_NO_MATCH )
     {
         AZLogInfo( ( "AzureIoTProvisioning ignoring unknown topic." ) );
         /* Maintaining the same state. */
@@ -392,28 +392,28 @@ static void prvProvClientParseResponse( AzureIoTProvisioningClient_t * pxAzurePr
         return;
     }
 
-    if ( az_iot_provisioning_client_operation_complete(pxAzureProvClient->_internal.xRegisterResponse.operation_status) )
+    if( az_iot_provisioning_client_operation_complete( pxAzureProvClient->_internal.xRegisterResponse.operation_status ) )
     {
-        switch (pxAzureProvClient->_internal.xRegisterResponse.operation_status)
+        switch( pxAzureProvClient->_internal.xRegisterResponse.operation_status )
         {
             case AZ_IOT_PROVISIONING_STATUS_ASSIGNED:
-            prvProvClientUpdateState( pxAzureProvClient, eAzureIoTSuccess );
-            break;
-            
+                prvProvClientUpdateState( pxAzureProvClient, eAzureIoTSuccess );
+                break;
+
             case AZ_IOT_PROVISIONING_STATUS_FAILED:
                 AZLogError( ( "AzureIoTProvisioning client registration failed with error %u: TrackingID: [%.*s] \"%.*s\"",
-                pxAzureProvClient->_internal.xRegisterResponse.registration_state.extended_error_code,
-                az_span_size(pxAzureProvClient->_internal.xRegisterResponse.registration_state.error_tracking_id),
-                az_span_ptr(pxAzureProvClient->_internal.xRegisterResponse.registration_state.error_tracking_id),
-                az_span_size(pxAzureProvClient->_internal.xRegisterResponse.registration_state.error_message),
-                az_span_ptr(pxAzureProvClient->_internal.xRegisterResponse.registration_state.error_message) ) );
+                              pxAzureProvClient->_internal.xRegisterResponse.registration_state.extended_error_code,
+                              az_span_size( pxAzureProvClient->_internal.xRegisterResponse.registration_state.error_tracking_id ),
+                              az_span_ptr( pxAzureProvClient->_internal.xRegisterResponse.registration_state.error_tracking_id ),
+                              az_span_size( pxAzureProvClient->_internal.xRegisterResponse.registration_state.error_message ),
+                              az_span_ptr( pxAzureProvClient->_internal.xRegisterResponse.registration_state.error_message ) ) );
                 prvProvClientUpdateState( pxAzureProvClient, eAzureIoTErrorServerError );
-            break;
+                break;
 
             case AZ_IOT_PROVISIONING_STATUS_DISABLED:
-                AZLogError( ( "AzureIoTProvisioning client: device is disabled.") );
+                AZLogError( ( "AzureIoTProvisioning client: device is disabled." ) );
                 prvProvClientUpdateState( pxAzureProvClient, eAzureIoTErrorServerError );
-            break;
+                break;
 
             default:
                 AZLogError( ( "AzureIoTProvisioning unexpected operation status %d", pxAzureProvClient->_internal.xRegisterResponse.operation_status ) );

--- a/source/azure_iot_provisioning_client.c
+++ b/source/azure_iot_provisioning_client.c
@@ -364,47 +364,69 @@ static void prvProvClientParseResponse( AzureIoTProvisioningClient_t * pxAzurePr
     {
         AZLogWarn( ( "AzureIoTProvisioning parse response action called in wrong state: [%u]",
                      pxAzureProvClient->_internal.ulWorkflowState ) );
+        return;
     }
-    else
+    
+    if( ( pxAzureProvClient->_internal.usLastResponseTopicLength == 0 ) ||
+        ( pxAzureProvClient->_internal.xLastResponsePayloadLength == 0 ) )
     {
-        if( ( pxAzureProvClient->_internal.usLastResponseTopicLength == 0 ) ||
-            ( pxAzureProvClient->_internal.xLastResponsePayloadLength == 0 ) )
-        {
-            AZLogError( ( "AzureIoTProvisioning client failed with invalid server response" ) );
-            prvProvClientUpdateState( pxAzureProvClient, eAzureIoTErrorInvalidResponse );
-            return;
-        }
+        AZLogError( ( "AzureIoTProvisioning client failed with invalid server response" ) );
+        prvProvClientUpdateState( pxAzureProvClient, eAzureIoTErrorInvalidResponse );
+        return;
+    }
 
-        xCoreResult =
-            az_iot_provisioning_client_parse_received_topic_and_payload( &pxAzureProvClient->_internal.xProvisioningClientCore,
-                                                                         xTopic, xPayload, &pxAzureProvClient->_internal.xRegisterResponse );
+    xCoreResult =
+        az_iot_provisioning_client_parse_received_topic_and_payload( &pxAzureProvClient->_internal.xProvisioningClientCore,
+                                                                        xTopic, xPayload, &pxAzureProvClient->_internal.xRegisterResponse );
 
-        if( az_result_failed( xCoreResult ) )
-        {
-            AZLogError( ( "AzureIoTProvisioning client failed to parse packet: core error=0x%08x", xCoreResult ) );
-            prvProvClientUpdateState( pxAzureProvClient, eAzureIoTErrorFailed );
-            return;
-        }
+    if ( xCoreResult == AZ_ERROR_IOT_TOPIC_NO_MATCH)
+    {
+        AZLogInfo( ( "AzureIoTProvisioning ignoring unknown topic." ) );
+        /* Maintaining the same state. */
+        return;
+    }
+    else if( az_result_failed( xCoreResult ) )
+    {
+        AZLogError( ( "AzureIoTProvisioning client failed to parse packet: core error=0x%08x", xCoreResult ) );
+        prvProvClientUpdateState( pxAzureProvClient, eAzureIoTErrorFailed );
+        return;
+    }
 
-        if( pxAzureProvClient->_internal.xRegisterResponse.operation_status == AZ_IOT_PROVISIONING_STATUS_ASSIGNED )
+    if ( az_iot_provisioning_client_operation_complete(pxAzureProvClient->_internal.xRegisterResponse.operation_status) )
+    {
+        switch (pxAzureProvClient->_internal.xRegisterResponse.operation_status)
         {
+            case AZ_IOT_PROVISIONING_STATUS_ASSIGNED:
             prvProvClientUpdateState( pxAzureProvClient, eAzureIoTSuccess );
+            break;
+            
+            case AZ_IOT_PROVISIONING_STATUS_FAILED:
+                AZLogError( ( "AzureIoTProvisioning client registration failed with error %d, extended error status: %u and no server retry time duration",
+                pxAzureProvClient->_internal.xRegisterResponse.registration_state.error_code,
+                pxAzureProvClient->_internal.xRegisterResponse.registration_state.extended_error_code ) );
+                prvProvClientUpdateState( pxAzureProvClient, eAzureIoTErrorServerError );
+            break;
+
+            case AZ_IOT_PROVISIONING_STATUS_DISABLED:
+                AZLogError( ( "AzureIoTProvisioning client: device is disabled.") );
+                prvProvClientUpdateState( pxAzureProvClient, eAzureIoTErrorServerError );
+            break;
+
+            default:
+                AZLogError( ( "AzureIoTProvisioning unexpected operation status %d", pxAzureProvClient->_internal.xRegisterResponse.operation_status ) );
         }
-        else if( pxAzureProvClient->_internal.xRegisterResponse.retry_after_seconds == 0 )
+    }
+    else /* Operation is not complete. */
+    {
+        if( pxAzureProvClient->_internal.xRegisterResponse.retry_after_seconds == 0 )
         {
-            AZLogError( ( "AzureIoTProvisioning client registration failed with error %d, extended error status: %u and no server retry time duration",
-                          pxAzureProvClient->_internal.xRegisterResponse.registration_state.error_code,
-                          pxAzureProvClient->_internal.xRegisterResponse.registration_state.extended_error_code ) );
-            /* Server responded with error with no retry.  */
-            prvProvClientUpdateState( pxAzureProvClient, eAzureIoTErrorServerError );
+            pxAzureProvClient->_internal.xRegisterResponse.retry_after_seconds = azureiotconfigPROVISIONING_POLLING_INTERVAL_S;
         }
-        else
-        {
-            pxAzureProvClient->_internal.ullRetryAfter =
-                pxAzureProvClient->_internal.xGetTimeFunction() +
-                pxAzureProvClient->_internal.xRegisterResponse.retry_after_seconds;
-            prvProvClientUpdateState( pxAzureProvClient, eAzureIoTErrorPending );
-        }
+
+        pxAzureProvClient->_internal.ullRetryAfter =
+            pxAzureProvClient->_internal.xGetTimeFunction() +
+            pxAzureProvClient->_internal.xRegisterResponse.retry_after_seconds;
+        prvProvClientUpdateState( pxAzureProvClient, eAzureIoTErrorPending );
     }
 }
 /*-----------------------------------------------------------*/

--- a/source/azure_iot_provisioning_client.c
+++ b/source/azure_iot_provisioning_client.c
@@ -401,9 +401,12 @@ static void prvProvClientParseResponse( AzureIoTProvisioningClient_t * pxAzurePr
             break;
             
             case AZ_IOT_PROVISIONING_STATUS_FAILED:
-                AZLogError( ( "AzureIoTProvisioning client registration failed with error %d, extended error status: %u and no server retry time duration",
-                pxAzureProvClient->_internal.xRegisterResponse.registration_state.error_code,
-                pxAzureProvClient->_internal.xRegisterResponse.registration_state.extended_error_code ) );
+                AZLogError( ( "AzureIoTProvisioning client registration failed with error %u: TrackingID: [%.*s] \"%.*s\"",
+                pxAzureProvClient->_internal.xRegisterResponse.registration_state.extended_error_code,
+                az_span_size(pxAzureProvClient->_internal.xRegisterResponse.registration_state.error_tracking_id),
+                az_span_ptr(pxAzureProvClient->_internal.xRegisterResponse.registration_state.error_tracking_id),
+                az_span_size(pxAzureProvClient->_internal.xRegisterResponse.registration_state.error_message),
+                az_span_ptr(pxAzureProvClient->_internal.xRegisterResponse.registration_state.error_message) ) );
                 prvProvClientUpdateState( pxAzureProvClient, eAzureIoTErrorServerError );
             break;
 

--- a/source/include/azure_iot_config_defaults.h
+++ b/source/include/azure_iot_config_defaults.h
@@ -65,6 +65,16 @@
 #endif
 
 /**
+ * @brief Provisioning polling interval.
+ *
+ * @details This is used for cases where the service does not supply a retry-after hint during the 
+ *          register and query operations.
+ */
+#ifndef azureiotconfigPROVISIONING_POLLING_INTERVAL_S
+    #define azureiotconfigPROVISIONING_POLLING_INTERVAL_S    ( 3U )
+#endif
+
+/**
  * @brief Macro that is called in the Azure IoT middleware library for logging "Error" level
  * messages.
  *

--- a/source/include/azure_iot_config_defaults.h
+++ b/source/include/azure_iot_config_defaults.h
@@ -67,7 +67,7 @@
 /**
  * @brief Provisioning polling interval.
  *
- * @details This is used for cases where the service does not supply a retry-after hint during the 
+ * @details This is used for cases where the service does not supply a retry-after hint during the
  *          register and query operations.
  */
 #ifndef azureiotconfigPROVISIONING_POLLING_INTERVAL_S

--- a/tests/e2e/Readme.md
+++ b/tests/e2e/Readme.md
@@ -1,4 +1,4 @@
-# Azure IoT middleware E2E Test Framework
+# Azure IoT Middleware E2E Test Framework
 
 ## Overview
 

--- a/tests/e2e/Readme.md
+++ b/tests/e2e/Readme.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The files in this directory implement the device SDK portion of E2E testing of the Embedded SDK for Azure IoT Convenience layer. For example, there are tests to make sure that a C2D is going through an IoTHub for real (NOT UT), and are properly received on a simulated device running the device SDK.
+The files in this directory implement the device SDK portion of E2E testing of the Azure IoT middleware for FreeRTOS. For example, there are tests to make sure that a C2D is going through an IoTHub for real (NOT UT), and are properly received on a simulated device running the device SDK.
 
 This is complicated by the fact that the Embedded SDK does *not* have a IoTHub service SDK.  So a naive approach of `CreateProcess(e2e_device_exe)` and having said process run the service and device SDK at the same time, checking internal state of each, will not work.
 

--- a/tests/ut/Readme.md
+++ b/tests/ut/Readme.md
@@ -1,0 +1,29 @@
+# Azure IoT Middleware Unit Test Framework
+
+## Overview
+
+The files in this directory implement the device SDK portion of unit testing of the Embedded SDK for Azure IoT Convenience layer.
+
+## Prerequisites
+
+The Unit Tests are using the [CMocka](https://cmocka.org/) framework.
+On Ubuntu, this can be installed by running:
+
+`sudo apt install libcmocka-dev libcmocka0`
+
+
+## How to run the unit tests
+* Note: Currently these tests are only supported to run on Linux.
+
+1. Make sure the middleware repository was cloned and has up-to-date submodules: `git submodule update`.
+1. Follow the [Building Guide](../../README.md#building) to set up a FreeRTOS directory outside of this repository making sure the FreeRTOS repository has its submodules up-to-date.
+1. Configure and build the unit tests:
+
+```bash
+cd tests/ut
+mkdir build
+cd build
+cmake -DFREERTOS_DIRECTORY='<path_to_FreeRTOS repo>' ..
+cmake --build . -j
+ctest
+```

--- a/tests/ut/Readme.md
+++ b/tests/ut/Readme.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The files in this directory implement the device SDK portion of unit testing of the Embedded SDK for Azure IoT Convenience layer.
+The files in this directory implement the device SDK portion of unit testing of the Azure IoT middleware for FreeRTOS.
 
 ## Prerequisites
 
@@ -10,7 +10,6 @@ The Unit Tests are using the [CMocka](https://cmocka.org/) framework.
 On Ubuntu, this can be installed by running:
 
 `sudo apt install libcmocka-dev libcmocka0`
-
 
 ## How to run the unit tests
 * Note: Currently these tests are only supported to run on Linux.

--- a/tests/ut/azure_iot_provisioning_client_ut.c
+++ b/tests/ut/azure_iot_provisioning_client_ut.c
@@ -164,31 +164,31 @@ static void prvGenerateResponse( AzureIoTMQTTPublishInfo_t * pxPublishInfo,
 
 static void prvGenerateShortFailureResponse( AzureIoTMQTTPublishInfo_t * pxPublishInfo )
 {
-    prvGenerateResponse (
+    prvGenerateResponse(
         pxPublishInfo,
         0,
         ucShortFailureHubResponse,
-        sizeof ( ucShortFailureHubResponse ) - 1);
+        sizeof( ucShortFailureHubResponse ) - 1 );
 }
 /*-----------------------------------------------------------*/
 
 static void prvGenerateDisabledResponse( AzureIoTMQTTPublishInfo_t * pxPublishInfo )
 {
-    prvGenerateResponse (
+    prvGenerateResponse(
         pxPublishInfo,
         0,
         ucDisabledHubResponse,
-        sizeof ( ucDisabledHubResponse ) - 1);
+        sizeof( ucDisabledHubResponse ) - 1 );
 }
 /*-----------------------------------------------------------*/
 
 static void prvGenerateFailureResponse( AzureIoTMQTTPublishInfo_t * pxPublishInfo )
 {
-    prvGenerateResponse (
+    prvGenerateResponse(
         pxPublishInfo,
         0,
         ucFailureHubResponse,
-        sizeof ( ucFailureHubResponse ) - 1);
+        sizeof( ucFailureHubResponse ) - 1 );
 }
 /*-----------------------------------------------------------*/
 
@@ -641,7 +641,7 @@ static void testAzureIoTProvisioningClient_Register_QueryPublishFailure( void **
     ( void ) ppvState;
 
     prvSetupTestProvisioningClient( &xTestProvisioningClient );
-    prvRegister ( &xTestProvisioningClient );
+    prvRegister( &xTestProvisioningClient );
 
     /* Publish Registration Query */
     will_return( AzureIoTMQTT_Publish, eAzureIoTMQTTSendFailed );
@@ -661,7 +661,7 @@ static void testAzureIoTProvisioningClient_Register_QueryShortFailure( void ** p
     ( void ) ppvState;
 
     prvSetupTestProvisioningClient( &xTestProvisioningClient );
-    prvRegister ( &xTestProvisioningClient );
+    prvRegister( &xTestProvisioningClient );
 
     /* Publish Registration Query */
     will_return( AzureIoTMQTT_Publish, eAzureIoTMQTTSuccess );
@@ -693,7 +693,7 @@ static void testAzureIoTProvisioningClient_Register_QueryFailure( void ** ppvSta
     ( void ) ppvState;
 
     prvSetupTestProvisioningClient( &xTestProvisioningClient );
-    prvRegister ( &xTestProvisioningClient );
+    prvRegister( &xTestProvisioningClient );
 
     /* Publish Registration Query */
     will_return( AzureIoTMQTT_Publish, eAzureIoTMQTTSuccess );
@@ -727,7 +727,7 @@ static void testAzureIoTProvisioningClient_Register_QueryDeviceDisabledResponse(
     ( void ) ppvState;
 
     prvSetupTestProvisioningClient( &xTestProvisioningClient );
-    prvRegister ( &xTestProvisioningClient );
+    prvRegister( &xTestProvisioningClient );
 
     /* Publish Registration Query */
     will_return( AzureIoTMQTT_Publish, eAzureIoTMQTTSuccess );
@@ -759,7 +759,7 @@ static void testAzureIoTProvisioningClient_Register_QueryInvalidResponseFailure(
     ( void ) ppvState;
 
     prvSetupTestProvisioningClient( &xTestProvisioningClient );
-    prvRegister ( &xTestProvisioningClient );
+    prvRegister( &xTestProvisioningClient );
 
     /* Publish Registration Query */
     will_return( AzureIoTMQTT_Publish, eAzureIoTMQTTSuccess );

--- a/tests/ut/azure_iot_provisioning_client_ut.c
+++ b/tests/ut/azure_iot_provisioning_client_ut.c
@@ -677,7 +677,7 @@ static void testAzureIoTProvisioningClient_Register_QueryShortFailure( void ** p
                                                            azureiotprovisioningNO_WAIT ),
                       eAzureIoTErrorPending );
 
-    /* Process Invalid response */
+    /* Process invalid response */
     assert_int_equal( AzureIoTProvisioningClient_Register( &xTestProvisioningClient,
                                                            azureiotprovisioningNO_WAIT ),
                       eAzureIoTErrorServerError );
@@ -709,7 +709,7 @@ static void testAzureIoTProvisioningClient_Register_QueryFailure( void ** ppvSta
                                                            azureiotprovisioningNO_WAIT ),
                       eAzureIoTErrorPending );
 
-    /* Process Invalid response */
+    /* Process invalid response */
     assert_int_equal( AzureIoTProvisioningClient_Register( &xTestProvisioningClient,
                                                            azureiotprovisioningNO_WAIT ),
                       eAzureIoTErrorServerError );
@@ -719,7 +719,7 @@ static void testAzureIoTProvisioningClient_Register_QueryFailure( void ** ppvSta
 
 
 
-static void testAzureIoTProvisioningClient_Register_QueryDeviceDisabledResponse( void ** ppvState )
+static void testAzureIoTProvisioningClient_Register_QueryDeviceDisabledResponseFailure( void ** ppvState )
 {
     AzureIoTProvisioningClient_t xTestProvisioningClient;
     AzureIoTMQTTPublishInfo_t xPublishInfo;
@@ -743,7 +743,7 @@ static void testAzureIoTProvisioningClient_Register_QueryDeviceDisabledResponse(
                                                            azureiotprovisioningNO_WAIT ),
                       eAzureIoTErrorPending );
 
-    /* Process Invalid response */
+    /* Process invalid response */
     assert_int_equal( AzureIoTProvisioningClient_Register( &xTestProvisioningClient,
                                                            azureiotprovisioningNO_WAIT ),
                       eAzureIoTErrorServerError );
@@ -775,7 +775,7 @@ static void testAzureIoTProvisioningClient_Register_QueryInvalidResponseFailure(
                                                            azureiotprovisioningNO_WAIT ),
                       eAzureIoTErrorPending );
 
-    /* Process Invalid response */
+    /* Process invalid response */
     assert_int_equal( AzureIoTProvisioningClient_Register( &xTestProvisioningClient,
                                                            azureiotprovisioningNO_WAIT ),
                       eAzureIoTErrorFailed );
@@ -949,7 +949,7 @@ uint32_t ulGetAllTests()
         cmocka_unit_test( testAzureIoTProvisioningClient_Register_QueryPublishFailure ),
         cmocka_unit_test( testAzureIoTProvisioningClient_Register_QueryShortFailure ),
         cmocka_unit_test( testAzureIoTProvisioningClient_Register_QueryFailure ),
-        cmocka_unit_test( testAzureIoTProvisioningClient_Register_QueryDeviceDisabledResponse ),
+        cmocka_unit_test( testAzureIoTProvisioningClient_Register_QueryDeviceDisabledResponseFailure ),
         cmocka_unit_test( testAzureIoTProvisioningClient_Register_QueryInvalidResponseFailure ),
         cmocka_unit_test( testAzureIoTProvisioningClient_Register_Success ),
         cmocka_unit_test( testAzureIoTProvisioningClient_GetDeviceAndHub_Failure ),


### PR DESCRIPTION
1. Fixing DPS state machine: Support devices that were disabled, support lack of retry-after and ignore unknown MQTT topics.
2. Adding better error logging.
3. Updating public API documentation.
4. Adding UT guidance.