### PR TITLE
Fix E2E build

### DIFF
--- a/tests/e2e/device/e2e_device_commands.c
+++ b/tests/e2e/device/e2e_device_commands.c
@@ -63,7 +63,6 @@ typedef struct E2E_TEST_COMMAND_STRUCT
 typedef E2E_TEST_COMMAND * E2E_TEST_COMMAND_HANDLE;
 /*-----------------------------------------------------------*/
 
-static const uint64_t ulGlobalEntryTime = 1639093301;
 static uint8_t * ucC2DCommandData = NULL;
 static uint32_t ulC2DCommandDataLength = 0;
 static AzureIoTHubClientCommandRequest_t * pxMethodCommandData = NULL;

--- a/tests/e2e/device/e2e_device_commands.c
+++ b/tests/e2e/device/e2e_device_commands.c
@@ -1286,14 +1286,7 @@ uint32_t ulE2EDeviceProcessCommands( AzureIoTHubClient_t * pxAzureIoTHubClient )
  * */
 uint64_t ulGetUnixTime( void )
 {
-    TickType_t xTickCount = 0;
-    uint64_t ulTime = 0UL;
-
-    xTickCount = xTaskGetTickCount();
-    ulTime = ( uint64_t ) xTickCount / configTICK_RATE_HZ;
-    ulTime = ( uint64_t ) ( ulTime + ulGlobalEntryTime );
-
-    return ulTime;
+    return time( NULL );
 }
 /*-----------------------------------------------------------*/
 

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -50,4 +50,6 @@ cat $dir/device/build/azure_iot_e2e_tests.map
 
 echo -e "::group::Running E2E tests"
 export DEVICE_TEST_EXE="$dir/device/build/azure_iot_e2e_tests"
+chown root $DEVICE_TEST_EXE
+chmod u+s $DEVICE_TEST_EXE
 cd $dir/service; stdbuf -o0 ./mocha_exec.sh alltest


### PR DESCRIPTION
Two things:

1. The newer versions of node drop privileges from child processes. The `chown` makes sure the executables are run as sudo for the network interface acquisition.
2. The E2E tests were hardcoded with a global entry date of `1639093301` which is Thu Dec 09 2021 23:41:41. That has passed and was causing invalid SAS keys to be generated. This change uses the real `time()` to get the unix time.