### PR TITLE
fix e2e tests | stuck running

### DIFF
--- a/.github/workflows/ci_tests_linux.yml
+++ b/.github/workflows/ci_tests_linux.yml
@@ -9,7 +9,7 @@ on:
     types: [labeled]
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     # Only allow build to start when label 'Run CI' added for forked
     # based PR
     if: ( github.event.pull_request.head.repo.fork == false ) ||

--- a/source/azure_iot_hub_client.c
+++ b/source/azure_iot_hub_client.c
@@ -34,7 +34,7 @@
 #endif /* azureiothubSUBACK_WAIT_INTERVAL_MS */
 
 #ifndef azureiothubUSER_AGENT
-    #define azureiothubUSER_AGENT    "DeviceClientType=c%2F" azureiotVERSION_STRING "%28FreeRTOS%29"
+    #define azureiothubUSER_AGENT    "c%2F" azureiotVERSION_STRING "%28FreeRTOS%29"
 #endif /* azureiothubUSER_AGENT */
 
 /*

--- a/tests/e2e/Readme.md
+++ b/tests/e2e/Readme.md
@@ -34,7 +34,7 @@ How do the Node service application and the C simulated device interact?
 
 * The [service](./service) directory contains code authored in TypeScript. This code simulates a service application using IOTHUB service SDK's interacting with a IOTHUB. The code:
 
-  * Creates a device on the IoThub, using IoTHub API's. This device is prefixed with the name `azure_services_port_e2e_` followed by a random string for uniqueness.
+  * Creates a device on the IoThub, using IoTHub API's. This device is prefixed with the name `azure_mid_freertos_e2e_` followed by a random string for uniqueness.
 
   * Creates a process built from the [device](./device) directory, passing the device_id, module_id and sas_token as the only command line arguments.
 

--- a/tests/e2e/service/common/e2e_test_cleanup.ts
+++ b/tests/e2e/service/common/e2e_test_cleanup.ts
@@ -37,10 +37,11 @@ async function iothubRegistryCleanup(hubConnectionString:string, registryPrefix:
     }
 
     expiredDevicesDescription.forEach((des) => {
-        console.log("Deleting device: " + des.deviceId)
+      console.log("Deleting device: " + des.deviceId)
     })
 
     await registry.removeDevices(expiredDevicesDescription, true);
+
 }
 
 let argv = require('yargs')
@@ -49,7 +50,7 @@ let argv = require('yargs')
         alias: 'c',
         describe: 'The connection string for the *IoTHub* instance to run tests against',
         type: 'string',
-        demandOption: false
+        demandOption: true
     })
     .option('cleanupAfter', {
         alias: 'e',
@@ -60,7 +61,7 @@ let argv = require('yargs')
     .argv;
 
 async function main() {
-    let e2eTestDevicePrefix = "azure_services_port_e2e_"
+    let e2eTestDevicePrefix = "azure_mid_freertos_e2e_"
     /* 86400000 is millisecond epoch in one day */
     let timeStamp:number = Date.now().valueOf() - 86400000 * argv.cleanupAfter;
     let expiryDate =  new Date(timeStamp);

--- a/tests/e2e/service/common/e2e_test_core.ts
+++ b/tests/e2e/service/common/e2e_test_core.ts
@@ -425,7 +425,7 @@ function verifyTelemetryMessageWithTimeout(testHubConnectionString:string, devic
 //
 function createTestDeviceAndTestProcess(testHubConnectionString:string, testexe:string, done) {
     // First, we create a new test device on IoTHub.  This will be destroyed on test tear down.
-    createTestDevice(testHubConnectionString, "azure_services_port_e2e_", function(err, newDeviceInfo) {
+    createTestDevice(testHubConnectionString, "azure_mid_freertos_e2e_", function(err, newDeviceInfo) {
         if (err) {
             console.log(`createTestDevice fails, error=<${err}>`)
             done(err, null)

--- a/tests/e2e/service/provisioning_client/e2e_iot_provisioning_client_test.ts
+++ b/tests/e2e/service/provisioning_client/e2e_iot_provisioning_client_test.ts
@@ -32,7 +32,7 @@ function testSetup(done) {
             else {
                 // Store information about this device for later
                 testHubInfo = newDeviceInfo
-                e2eTestCore.createProvisioningEnrollment(testProvisioningConnectionString, "azure_services_port_e2e_", (err, newEnrollmentInfo) => {
+                e2eTestCore.createProvisioningEnrollment(testProvisioningConnectionString, "azure_mid_freertos_e2e_", (err, newEnrollmentInfo) => {
                     // Store information about this device for later
                     testEnrollmentInfo = newEnrollmentInfo
                     done(err)


### PR DESCRIPTION
- Reverts back to Ubuntu 18.04 since something in the dependencies has broken with Ubuntu 20.04. [Tracking with this Github Issue](https://github.com/Azure/azure-iot-middleware-freertos/issues/241).
- Changes the device id names which are created since this matches Azure RTOS's and it makes it difficult to search through logs.