### PR TITLE
New AzureIoTResult eAzureIoTErrorServerRefused

### DIFF
--- a/source/azure_iot_hub_client.c
+++ b/source/azure_iot_hub_client.c
@@ -795,7 +795,15 @@ AzureIoTResult_t AzureIoTHubClient_Connect( AzureIoTHubClient_t * pxAzureIoTHubC
                 AZLogError( ( "Failed to establish MQTT connection: Server=%.*s, MQTT error=0x%08x",
                               pxAzureIoTHubClient->_internal.ulHostnameLength, ( const char * ) pxAzureIoTHubClient->_internal.pucHostname,
                               xMQTTResult ) );
-                xResult = eAzureIoTErrorFailed;
+
+                if( xMQTTResult == eAzureIoTMQTTServerRefused )
+                {
+                    xResult = eAzureIoTErrorServerRefused;
+                }
+                else
+                {
+                    xResult = eAzureIoTErrorFailed;
+                }
             }
             else
             {

--- a/source/include/azure_iot_result.h
+++ b/source/include/azure_iot_result.h
@@ -44,6 +44,7 @@ typedef enum AzureIoTResult
     eAzureIoTErrorTokenGenerationFailed, /**< There was a failure. */
     eAzureIoTErrorEndOfProperties,       /**< End of properties when iterating with AzureIoTHubClientProperties_GetNextComponentProperty(). */
     eAzureIoTErrorInvalidResponse,       /**< Invalid response from server. */
+    eAzureIoTErrorServerRefused,         /**< The server refused a CONNECT or SUBSCRIBE. */
     eAzureIoTErrorUnexpectedChar,        /**< Input can't be successfully parsed. */
 
     /* === JSON: Error results === */

--- a/tests/ut/azure_iot_hub_client_ut.c
+++ b/tests/ut/azure_iot_hub_client_ut.c
@@ -424,7 +424,7 @@ static void testAzureIoTHubClient_Connect_MQTTConnectFailure( void ** ppvState )
                                                  false,
                                                  &xSessionPresent,
                                                  60 ),
-                      eAzureIoTErrorFailed );
+                      eAzureIoTErrorServerRefused );
 }
 /*-----------------------------------------------------------*/
 


### PR DESCRIPTION
AzureIoTHubClient_Connect returns the new return code eAzureIoTErrorServerRefused if the xMQTTResult is eAzureIoTMQTTServerRefused as suggested by my [feature request](https://github.com/Azure/azure-iot-middleware-freertos/issues/242).