### PR TITLE
Delete download action (deprecated)

### DIFF
--- a/source/include/azure_iot_adu_client.h
+++ b/source/include/azure_iot_adu_client.h
@@ -80,7 +80,6 @@ typedef struct AzureIoTADUClientDeviceProperties
  */
 typedef enum AzureIoTADUAction
 {
-    eAzureIoTADUActionDownload = 0,
     eAzureIoTADUActionApplyDownload = 3,
     eAzureIoTADUActionCancel = 255
 } AzureIoTADUAction_t;


### PR DESCRIPTION
Based on the docs, `download` is no longer an action.

https://docs.microsoft.com/en-us/azure/iot-hub-device-update/device-update-plug-and-play#action