### PR TITLE
Remove -j for docs build

### DIFF
--- a/.github/scripts/doxygen.sh
+++ b/.github/scripts/doxygen.sh
@@ -16,7 +16,7 @@ pushd doxygen
 mkdir build
 pushd build
 cmake -G "Unix Makefiles" ..
-make -j
+make
 sudo make install
 popd
 popd


### PR DESCRIPTION
- Worked locally when I tested it but the gate is having issues building with `-j`.