### PR TITLE
change dps local var to a size_t

### DIFF
--- a/source/azure_iot_provisioning_client.c
+++ b/source/azure_iot_provisioning_client.c
@@ -314,7 +314,7 @@ static void prvProvClientRequest( AzureIoTProvisioningClient_t * pxAzureProvClie
                                                             xCustomPayloadProperty, NULL,
                                                             ( uint8_t * ) ( pxAzureProvClient->_internal.pucScratchBuffer +
                                                                             xMQTTTopicLength ),
-                                                            ( size_t ) xMQTTPayloadLength, ( size_t * ) &xMQTTPayloadLength );
+                                                            ( size_t ) xMQTTPayloadLength, &xMQTTPayloadLength );
 
         if( az_result_failed( xCoreResult ) )
         {

--- a/source/azure_iot_provisioning_client.c
+++ b/source/azure_iot_provisioning_client.c
@@ -271,7 +271,7 @@ static void prvProvClientRequest( AzureIoTProvisioningClient_t * pxAzureProvClie
     AzureIoTResult_t xResult;
     AzureIoTMQTTPublishInfo_t xMQTTPublishInfo = { 0 };
     size_t xMQTTTopicLength;
-    uint32_t xMQTTPayloadLength = 0;
+    size_t xMQTTPayloadLength = 0;
     uint16_t usPublishPacketIdentifier;
     az_result xCoreResult;
     az_span xCustomPayloadProperty = az_span_create( ( uint8_t * ) pxAzureProvClient->_internal.pucRegistrationPayload,


### PR DESCRIPTION
The changed value is used below and casted to a `size_t *`, which was making it larger than a uint32_t on 64 bit systems. This caused memory corruption.
https://github.com/Azure/azure-iot-middleware-freertos/blob/35dd34ea98b209e330365dd8c1f83b5908ebf51f/source/azure_iot_provisioning_client.c#L317