### PR TITLE
Return result code for http initialize request headers

### DIFF
--- a/ports/coreHTTP/azure_iot_core_http.c
+++ b/ports/coreHTTP/azure_iot_core_http.c
@@ -104,7 +104,7 @@ AzureIoTHTTPResult_t AzureIoTHTTP_Init( AzureIoTHTTPHandle_t xHTTPHandle,
 
     xHTTPHandle->pxHTTPTransport = pxHTTPTransport;
 
-    HTTPClient_InitializeRequestHeaders( &xHTTPHandle->xRequestHeaders, &xHTTPHandle->xRequestInfo );
+    xHttpLibraryStatus = HTTPClient_InitializeRequestHeaders( &xHTTPHandle->xRequestHeaders, &xHTTPHandle->xRequestInfo );
 
     return prvTranslateToAzureIoTHTTPResult( xHttpLibraryStatus );
 }
@@ -201,7 +201,7 @@ AzureIoTHTTPResult_t AzureIoTHTTP_RequestSizeInit( AzureIoTHTTPHandle_t xHTTPHan
 
     xHTTPHandle->pxHTTPTransport = pxHTTPTransport;
 
-    HTTPClient_InitializeRequestHeaders( &xHTTPHandle->xRequestHeaders, &xHTTPHandle->xRequestInfo );
+    xHttpLibraryStatus = HTTPClient_InitializeRequestHeaders( &xHTTPHandle->xRequestHeaders, &xHTTPHandle->xRequestInfo );
 
     return prvTranslateToAzureIoTHTTPResult( xHttpLibraryStatus );
 }


### PR DESCRIPTION
Properly propagates failure if there isn't enough space to initialize the headers. Fixes https://github.com/Azure/azure-iot-middleware-freertos/issues/312