### PR TITLE
Feature/dps csr preview

### DIFF
--- a/source/azure_iot_hub_client.c
+++ b/source/azure_iot_hub_client.c
@@ -1584,9 +1584,9 @@ AzureIoTResult_t AzureIoTHubClient_SendCertificateSigningRequest( AzureIoTHubCli
                                                                     uint32_t ulCSRLength,
                                                                     const uint8_t * pucRequestID,
                                                                     uint16_t usRequestIDLength,
+                                                                    const AzureIoTHubClientCertificateSigningRequestOptions_t * pxOptions,
                                                                     uint8_t * pucPayloadBuffer,
-                                                                    uint32_t ulPayloadBufferLength,
-                                                                    const AzureIoTHubClientCertificateSigningRequestOptions_t * pxOptions )
+                                                                    uint32_t ulPayloadBufferLength )
 {
     AzureIoTMQTTResult_t xMQTTResult;
     AzureIoTResult_t xResult;

--- a/source/azure_iot_hub_client.c
+++ b/source/azure_iot_hub_client.c
@@ -1586,7 +1586,7 @@ AzureIoTResult_t AzureIoTHubClient_SendCertificateSigningRequest( AzureIoTHubCli
                                                                     uint16_t usRequestIDLength,
                                                                     uint8_t * pucPayloadBuffer,
                                                                     uint32_t ulPayloadBufferLength,
-                                                                    AzureIoTHubClientCertificateSigningRequestOptions_t * pxOptions )
+                                                                    const AzureIoTHubClientCertificateSigningRequestOptions_t * pxOptions )
 {
     AzureIoTMQTTResult_t xMQTTResult;
     AzureIoTResult_t xResult;

--- a/source/azure_iot_hub_client.c
+++ b/source/azure_iot_hub_client.c
@@ -50,6 +50,7 @@
 #define azureiothubRECEIVE_CONTEXT_INDEX_C2D           ( 0 )
 #define azureiothubRECEIVE_CONTEXT_INDEX_COMMANDS      ( 1 )
 #define azureiothubRECEIVE_CONTEXT_INDEX_PROPERTIES    ( 2 )
+#define azureiothubRECEIVE_CONTEXT_INDEX_CSR           ( 3 )
 
 #define azureiothubCOMMAND_EMPTY_RESPONSE              "{}"
 
@@ -374,6 +375,61 @@ static uint32_t prvAzureIoTHubClientPropertiesProcess( AzureIoTHubClientReceiveC
                 AZLogDebug( ( "Returning from property callback" ) );
             }
         }
+    }
+
+    return ( uint32_t ) xResult;
+}
+/*-----------------------------------------------------------*/
+
+/**
+ *
+ * Check/Process messages for incoming certificate signing responses.
+ *
+ * */
+static uint32_t prvAzureIoTHubClientCSRProcess( AzureIoTHubClientReceiveContext_t * pxContext,
+                                                 AzureIoTHubClient_t * pxAzureIoTHubClient,
+                                                 void * pvPublishInfo )
+{
+    AzureIoTResult_t xResult;
+    AzureIoTHubClientCertificateSigningResponse_t xCSRResponse = { 0 };
+    AzureIoTMQTTPublishInfo_t * xMQTTPublishInfo = ( AzureIoTMQTTPublishInfo_t * ) pvPublishInfo;
+    az_result xCoreResult;
+    az_iot_hub_client_certificate_signing_response_info xOutResponseInfo;
+    az_span xTopicSpan = az_span_create( ( uint8_t * ) xMQTTPublishInfo->pcTopicName, xMQTTPublishInfo->usTopicNameLength );
+
+    /* Failed means no topic match. This means the message is not for certificate signing. */
+    xCoreResult = az_iot_hub_client_certificate_signing_request_parse_received_topic( &pxAzureIoTHubClient->_internal.xAzureIoTHubClientCore,
+                                                                                      xTopicSpan, &xOutResponseInfo );
+
+    if( az_result_failed( xCoreResult ) )
+    {
+        xResult = AzureIoT_TranslateCoreError( xCoreResult );
+    }
+    else
+    {
+        AZLogDebug( ( "Certificate signing response topic: %.*s  with payload : %.*s",
+                      xMQTTPublishInfo->usTopicNameLength,
+                      xMQTTPublishInfo->pcTopicName,
+                      xMQTTPublishInfo->xPayloadLength,
+                      ( const char * ) xMQTTPublishInfo->pvPayload ) );
+
+        if( pxContext->_internal.callbacks.xCertificateSigningCallback )
+        {
+            xCSRResponse.xResponseType =
+                ( AzureIoTHubClientCertificateSigningResponseType_t ) xOutResponseInfo.response_type;
+            xCSRResponse.xMessageStatus = ( AzureIoTHubMessageStatus_t ) xOutResponseInfo.status_code;
+            xCSRResponse.pvMessagePayload = xMQTTPublishInfo->pvPayload;
+            xCSRResponse.ulPayloadLength = ( uint32_t ) xMQTTPublishInfo->xPayloadLength;
+            xCSRResponse.pucRequestID = az_span_ptr( xOutResponseInfo.request_id );
+            xCSRResponse.usRequestIDLength = ( uint16_t ) az_span_size( xOutResponseInfo.request_id );
+
+            AZLogDebug( ( "Invoking certificate signing callback" ) );
+            pxContext->_internal.callbacks.xCertificateSigningCallback( &xCSRResponse,
+                                                                        pxContext->_internal.pvCallbackContext );
+            AZLogDebug( ( "Returned from certificate signing callback" ) );
+        }
+
+        xResult = eAzureIoTSuccess;
     }
 
     return ( uint32_t ) xResult;
@@ -1415,6 +1471,195 @@ AzureIoTResult_t AzureIoTHubClient_RequestPropertiesAsync( AzureIoTHubClient_t *
                                                       &xMQTTPublishInfo, 0 ) ) != eAzureIoTMQTTSuccess )
             {
                 AZLogError( ( "Failed to Publish get properties message: MQTT error=0x%08x", xMQTTResult ) );
+                xResult = eAzureIoTErrorPublishFailed;
+            }
+            else
+            {
+                xResult = eAzureIoTSuccess;
+            }
+        }
+    }
+
+    return xResult;
+}
+/*-----------------------------------------------------------*/
+
+AzureIoTResult_t AzureIoTHubClient_SubscribeCertificateSigningResponse( AzureIoTHubClient_t * pxAzureIoTHubClient,
+                                                                         AzureIoTHubClientCertificateSigningCallback_t xCallback,
+                                                                         void * prvCallbackContext,
+                                                                         uint32_t ulTimeoutMilliseconds )
+{
+    AzureIoTMQTTSubscribeInfo_t xMqttSubscription = { 0 };
+    AzureIoTMQTTResult_t xMQTTResult;
+    AzureIoTResult_t xResult;
+    uint16_t usSubscribePacketIdentifier;
+    AzureIoTHubClientReceiveContext_t * pxContext;
+
+    if( ( pxAzureIoTHubClient == NULL ) ||
+        ( xCallback == NULL ) )
+    {
+        AZLogError( ( "AzureIoTHubClient_SubscribeCertificateSigningResponse failed: invalid argument" ) );
+        xResult = eAzureIoTErrorInvalidArgument;
+    }
+    else
+    {
+        pxContext = &pxAzureIoTHubClient->_internal.xReceiveContext[ azureiothubRECEIVE_CONTEXT_INDEX_CSR ];
+        xMqttSubscription.xQoS = eAzureIoTMQTTQoS0;
+        xMqttSubscription.pcTopicFilter = ( const uint8_t * ) AZ_IOT_HUB_CLIENT_CERTIFICATE_SIGNING_RESPONSE_SUBSCRIBE_TOPIC;
+        xMqttSubscription.usTopicFilterLength = ( uint16_t ) sizeof( AZ_IOT_HUB_CLIENT_CERTIFICATE_SIGNING_RESPONSE_SUBSCRIBE_TOPIC ) - 1;
+        usSubscribePacketIdentifier = AzureIoTMQTT_GetPacketId( &( pxAzureIoTHubClient->_internal.xMQTTContext ) );
+
+        AZLogDebug( ( "Attempting to subscribe to the MQTT topic: %s", AZ_IOT_HUB_CLIENT_CERTIFICATE_SIGNING_RESPONSE_SUBSCRIBE_TOPIC ) );
+
+        if( ( xMQTTResult = AzureIoTMQTT_Subscribe( &( pxAzureIoTHubClient->_internal.xMQTTContext ),
+                                                    &xMqttSubscription, 1, usSubscribePacketIdentifier ) ) != eAzureIoTMQTTSuccess )
+        {
+            AZLogError( ( "Certificate signing subscribe failed: MQTT error=0x%08x", xMQTTResult ) );
+            xResult = eAzureIoTErrorSubscribeFailed;
+        }
+        else
+        {
+            pxContext->_internal.usState = azureiothubTOPIC_SUBSCRIBE_STATE_SUB;
+            pxContext->_internal.usMqttSubPacketID = usSubscribePacketIdentifier;
+            pxContext->_internal.pxProcessFunction = prvAzureIoTHubClientCSRProcess;
+            pxContext->_internal.callbacks.xCertificateSigningCallback = xCallback;
+            pxContext->_internal.pvCallbackContext = prvCallbackContext;
+
+            if( ( xResult = prvWaitForSubAck( pxAzureIoTHubClient, pxContext,
+                                              ulTimeoutMilliseconds ) ) != eAzureIoTSuccess )
+            {
+                AZLogError( ( "Wait for certificate signing sub ack failed : error=0x%08x", xResult ) );
+                memset( pxContext, 0, sizeof( AzureIoTHubClientReceiveContext_t ) );
+            }
+        }
+    }
+
+    return xResult;
+}
+/*-----------------------------------------------------------*/
+
+AzureIoTResult_t AzureIoTHubClient_UnsubscribeCertificateSigningResponse( AzureIoTHubClient_t * pxAzureIoTHubClient )
+{
+    AzureIoTMQTTSubscribeInfo_t xMqttSubscription = { 0 };
+    AzureIoTMQTTResult_t xMQTTResult;
+    AzureIoTResult_t xResult;
+    uint16_t usSubscribePacketIdentifier;
+    AzureIoTHubClientReceiveContext_t * pxContext;
+
+    if( pxAzureIoTHubClient == NULL )
+    {
+        AZLogError( ( "AzureIoTHubClient_UnsubscribeCertificateSigningResponse failed: invalid argument" ) );
+        xResult = eAzureIoTErrorInvalidArgument;
+    }
+    else
+    {
+        pxContext = &pxAzureIoTHubClient->_internal.xReceiveContext[ azureiothubRECEIVE_CONTEXT_INDEX_CSR ];
+        xMqttSubscription.xQoS = eAzureIoTMQTTQoS0;
+        xMqttSubscription.pcTopicFilter = ( const uint8_t * ) AZ_IOT_HUB_CLIENT_CERTIFICATE_SIGNING_RESPONSE_SUBSCRIBE_TOPIC;
+        xMqttSubscription.usTopicFilterLength = ( uint16_t ) sizeof( AZ_IOT_HUB_CLIENT_CERTIFICATE_SIGNING_RESPONSE_SUBSCRIBE_TOPIC ) - 1;
+        usSubscribePacketIdentifier = AzureIoTMQTT_GetPacketId( &( pxAzureIoTHubClient->_internal.xMQTTContext ) );
+
+        AZLogDebug( ( "Attempting to unsubscribe from the MQTT topic: %s", AZ_IOT_HUB_CLIENT_CERTIFICATE_SIGNING_RESPONSE_SUBSCRIBE_TOPIC ) );
+
+        if( ( xMQTTResult = AzureIoTMQTT_Unsubscribe( &( pxAzureIoTHubClient->_internal.xMQTTContext ),
+                                                      &xMqttSubscription, 1,
+                                                      usSubscribePacketIdentifier ) ) != eAzureIoTMQTTSuccess )
+        {
+            AZLogError( ( "Certificate signing unsubscribe failed: MQTT error=0x%08x", xMQTTResult ) );
+            xResult = eAzureIoTErrorUnsubscribeFailed;
+        }
+        else
+        {
+            memset( pxContext, 0, sizeof( AzureIoTHubClientReceiveContext_t ) );
+            xResult = eAzureIoTSuccess;
+        }
+    }
+
+    return xResult;
+}
+/*-----------------------------------------------------------*/
+
+AzureIoTResult_t AzureIoTHubClient_SendCertificateSigningRequest( AzureIoTHubClient_t * pxAzureIoTHubClient,
+                                                                    const uint8_t * pucCSR,
+                                                                    uint32_t ulCSRLength,
+                                                                    const uint8_t * pucRequestID,
+                                                                    uint16_t usRequestIDLength,
+                                                                    uint8_t * pucPayloadBuffer,
+                                                                    uint32_t ulPayloadBufferLength,
+                                                                    AzureIoTHubClientCertificateSigningRequestOptions_t * pxOptions )
+{
+    AzureIoTMQTTResult_t xMQTTResult;
+    AzureIoTResult_t xResult;
+    AzureIoTMQTTPublishInfo_t xMQTTPublishInfo = { 0 };
+    az_iot_hub_client_certificate_signing_request xCSRRequest;
+    az_span xRequestID;
+    size_t xTopicLength;
+    size_t xPayloadLength;
+    az_result xCoreResult;
+
+    if( ( pxAzureIoTHubClient == NULL ) ||
+        ( pucCSR == NULL ) || ( ulCSRLength == 0 ) ||
+        ( pucRequestID == NULL ) || ( usRequestIDLength == 0 ) ||
+        ( pucPayloadBuffer == NULL ) || ( ulPayloadBufferLength == 0 ) )
+    {
+        AZLogError( ( "AzureIoTHubClient_SendCertificateSigningRequest failed: invalid argument" ) );
+        xResult = eAzureIoTErrorInvalidArgument;
+    }
+    else if( pxAzureIoTHubClient->_internal.xReceiveContext[ azureiothubRECEIVE_CONTEXT_INDEX_CSR ]._internal.usState !=
+             azureiothubTOPIC_SUBSCRIBE_STATE_SUBACK )
+    {
+        AZLogError( ( "AzureIoTHubClient_SendCertificateSigningRequest failed: CSR topic not subscribed" ) );
+        xResult = eAzureIoTErrorTopicNotSubscribed;
+    }
+    else
+    {
+        xRequestID = az_span_create( ( uint8_t * ) pucRequestID, ( int32_t ) usRequestIDLength );
+        xCSRRequest.csr = az_span_create( ( uint8_t * ) pucCSR, ( int32_t ) ulCSRLength );
+
+        if( ( pxOptions != NULL ) && ( pxOptions->pucReplace != NULL ) && ( pxOptions->usReplaceLength > 0 ) )
+        {
+            xCSRRequest.replace = az_span_create( ( uint8_t * ) pxOptions->pucReplace, ( int32_t ) pxOptions->usReplaceLength );
+        }
+        else
+        {
+            xCSRRequest.replace = AZ_SPAN_EMPTY;
+        }
+
+        if( az_result_failed(
+                xCoreResult =
+                    az_iot_hub_client_certificate_signing_request_get_publish_topic( &pxAzureIoTHubClient->_internal.xAzureIoTHubClientCore,
+                                                                                     xRequestID,
+                                                                                     ( char * ) pxAzureIoTHubClient->_internal.pucWorkingBuffer,
+                                                                                     pxAzureIoTHubClient->_internal.ulWorkingBufferLength,
+                                                                                     &xTopicLength ) ) )
+        {
+            AZLogError( ( "Failed to get CSR publish topic: core error=0x%08x", ( uint16_t ) xCoreResult ) );
+            xResult = AzureIoT_TranslateCoreError( xCoreResult );
+        }
+        else if( az_result_failed(
+                     xCoreResult =
+                         az_iot_hub_client_certificate_signing_request_get_request_payload( &pxAzureIoTHubClient->_internal.xAzureIoTHubClientCore,
+                                                                                            &xCSRRequest,
+                                                                                            pucPayloadBuffer,
+                                                                                            ulPayloadBufferLength,
+                                                                                            &xPayloadLength ) ) )
+        {
+            AZLogError( ( "Failed to get CSR request payload: core error=0x%08x", ( uint16_t ) xCoreResult ) );
+            xResult = AzureIoT_TranslateCoreError( xCoreResult );
+        }
+        else
+        {
+            xMQTTPublishInfo.xQOS = eAzureIoTMQTTQoS1;
+            xMQTTPublishInfo.pcTopicName = pxAzureIoTHubClient->_internal.pucWorkingBuffer;
+            xMQTTPublishInfo.usTopicNameLength = ( uint16_t ) xTopicLength;
+            xMQTTPublishInfo.pvPayload = ( const void * ) pucPayloadBuffer;
+            xMQTTPublishInfo.xPayloadLength = xPayloadLength;
+
+            if( ( xMQTTResult = AzureIoTMQTT_Publish( &( pxAzureIoTHubClient->_internal.xMQTTContext ),
+                                                      &xMQTTPublishInfo,
+                                                      AzureIoTMQTT_GetPacketId( &( pxAzureIoTHubClient->_internal.xMQTTContext ) ) ) ) != eAzureIoTMQTTSuccess )
+            {
+                AZLogError( ( "Failed to Publish CSR message: MQTT error=0x%08x", xMQTTResult ) );
                 xResult = eAzureIoTErrorPublishFailed;
             }
             else

--- a/source/include/azure_iot_hub_client.h
+++ b/source/include/azure_iot_hub_client.h
@@ -590,7 +590,7 @@ AzureIoTResult_t AzureIoTHubClient_SendCertificateSigningRequest( AzureIoTHubCli
                                                                     uint16_t usRequestIDLength,
                                                                     uint8_t * pucPayloadBuffer,
                                                                     uint32_t ulPayloadBufferLength,
-                                                                    AzureIoTHubClientCertificateSigningRequestOptions_t * pxOptions );
+                                                                    const AzureIoTHubClientCertificateSigningRequestOptions_t * pxOptions );
 
 #include "azure/core/_az_cfg_suffix.h"
 

--- a/source/include/azure_iot_hub_client.h
+++ b/source/include/azure_iot_hub_client.h
@@ -176,7 +176,9 @@ typedef struct AzureIoTHubClientCertificateSigningResponse
  */
 typedef struct AzureIoTHubClientCertificateSigningRequestOptions
 {
-    const uint8_t * pucReplace;   /**< Optional replace field ("*" or a specific request ID to replace). */
+    const uint8_t * pucReplace;   /**< Optional replace field. Use "*" to replace any active request, or pass
+                                      a prior request ID (see #AzureIoTHubClient_SendCertificateSigningRequest
+                                      pucRequestID) to replace a specific one. */
     uint16_t usReplaceLength;     /**< The length of the replace field. */
 } AzureIoTHubClientCertificateSigningRequestOptions_t;
 
@@ -576,8 +578,13 @@ AzureIoTResult_t AzureIoTHubClient_UnsubscribeCertificateSigningResponse( AzureI
  * @param[in] pxAzureIoTHubClient The #AzureIoTHubClient_t * to use for this call.
  * @param[in] pucCSR The pointer to the base64-encoded PKCS#10 CSR (without PEM headers).
  * @param[in] ulCSRLength The length of the CSR.
- * @param[in] pucRequestID The pointer to the request ID string.
- * @param[in] usRequestIDLength The length of the request ID.
+ * @param[in] pucRequestID The pointer to the request ID string. Must be 4 to 36 ASCII characters
+ *                         inclusive, containing only alphanumerics and dashes. Must not begin or
+ *                         end with a dash. A UUID/GUID (e.g. "550e8400-e29b-41d4-a716-446655440000")
+ *                         is a suitable choice for production applications. Store this request ID durably;
+ *                         on reconnect or retry, pass it as #AzureIoTHubClientCertificateSigningRequestOptions_t::pucReplace
+ *                         to replace the prior in-progress operation.
+ * @param[in] usRequestIDLength The length of the request ID (4 to 36 inclusive).
  * @param[in] pucPayloadBuffer The buffer to use for building the JSON request payload.
  * @param[in] ulPayloadBufferLength The length of the payload buffer.
  * @param[in] pxOptions __[nullable]__ Optional #AzureIoTHubClientCertificateSigningRequestOptions_t for extra options (e.g., replace).

--- a/source/include/azure_iot_hub_client.h
+++ b/source/include/azure_iot_hub_client.h
@@ -67,7 +67,7 @@ typedef enum AzureIoTHubMessageType
     eAzureIoTHubPropertiesRequestedMessage,        /**< The message is a response from a property request (payload contains the property document). */
     eAzureIoTHubPropertiesReportedResponseMessage, /**< The message is a reported property status response. */
     eAzureIoTHubPropertiesWritablePropertyMessage, /**< The message is a writable property message (incoming from the service). */
-    eAzureIoTHubCertificateSigningMessage,         /**< The message is a certificate signing response. */
+    eAzureIoTHubCertificateSigningResponseMessage, /**< The message is a certificate signing response. */
 } AzureIoTHubMessageType_t;
 
 /**
@@ -585,9 +585,9 @@ AzureIoTResult_t AzureIoTHubClient_UnsubscribeCertificateSigningResponse( AzureI
  *                         on reconnect or retry, pass it as #AzureIoTHubClientCertificateSigningRequestOptions_t::pucReplace
  *                         to replace the prior in-progress operation.
  * @param[in] usRequestIDLength The length of the request ID (4 to 36 inclusive).
+ * @param[in] pxOptions __[nullable]__ Optional #AzureIoTHubClientCertificateSigningRequestOptions_t for extra options (e.g., replace).
  * @param[in] pucPayloadBuffer The buffer to use for building the JSON request payload.
  * @param[in] ulPayloadBufferLength The length of the payload buffer.
- * @param[in] pxOptions __[nullable]__ Optional #AzureIoTHubClientCertificateSigningRequestOptions_t for extra options (e.g., replace).
  * @return An #AzureIoTResult_t with the result of the operation.
  */
 AzureIoTResult_t AzureIoTHubClient_SendCertificateSigningRequest( AzureIoTHubClient_t * pxAzureIoTHubClient,
@@ -595,9 +595,9 @@ AzureIoTResult_t AzureIoTHubClient_SendCertificateSigningRequest( AzureIoTHubCli
                                                                     uint32_t ulCSRLength,
                                                                     const uint8_t * pucRequestID,
                                                                     uint16_t usRequestIDLength,
+                                                                    const AzureIoTHubClientCertificateSigningRequestOptions_t * pxOptions,
                                                                     uint8_t * pucPayloadBuffer,
-                                                                    uint32_t ulPayloadBufferLength,
-                                                                    const AzureIoTHubClientCertificateSigningRequestOptions_t * pxOptions );
+                                                                    uint32_t ulPayloadBufferLength );
 
 #include "azure/core/_az_cfg_suffix.h"
 

--- a/source/include/azure_iot_hub_client.h
+++ b/source/include/azure_iot_hub_client.h
@@ -32,7 +32,7 @@
 /**
  * @brief Total number of features which could be subscribed to.
  */
-#define azureiothubSUBSCRIBE_FEATURE_COUNT    ( 3 )
+#define azureiothubSUBSCRIBE_FEATURE_COUNT    ( 4 )
 
 /**
  * @brief Macro which should be used to create an array of #AzureIoTHubClientComponent_t
@@ -67,6 +67,7 @@ typedef enum AzureIoTHubMessageType
     eAzureIoTHubPropertiesRequestedMessage,        /**< The message is a response from a property request (payload contains the property document). */
     eAzureIoTHubPropertiesReportedResponseMessage, /**< The message is a reported property status response. */
     eAzureIoTHubPropertiesWritablePropertyMessage, /**< The message is a writable property message (incoming from the service). */
+    eAzureIoTHubCertificateSigningMessage,         /**< The message is a certificate signing response. */
 } AzureIoTHubMessageType_t;
 
 /**
@@ -145,6 +146,41 @@ typedef struct AzureIoTHubClientPropertiesResponse
 } AzureIoTHubClientPropertiesResponse_t;
 
 /**
+ * @brief Response type for certificate signing operations.
+ */
+typedef enum AzureIoTHubClientCertificateSigningResponseType
+{
+    eAzureIoTHubClientCertificateSigningResponseAccepted = 1,  /**< 202 - CSR accepted, pending issuance. */
+    eAzureIoTHubClientCertificateSigningResponseCompleted = 2, /**< 200 - Certificate issued successfully. */
+    eAzureIoTHubClientCertificateSigningResponseError = 3,     /**< 4xx/5xx - Error response. */
+} AzureIoTHubClientCertificateSigningResponseType_t;
+
+/**
+ * @brief IoT Hub Certificate Signing Response struct.
+ */
+typedef struct AzureIoTHubClientCertificateSigningResponse
+{
+    AzureIoTHubClientCertificateSigningResponseType_t xResponseType; /**< The type of response (accepted, completed, or error). */
+
+    AzureIoTHubMessageStatus_t xMessageStatus;                      /**< The HTTP-like status code (200, 202, 4xx, 5xx). */
+
+    const void * pvMessagePayload;                                   /**< The pointer to the response payload. */
+    uint32_t ulPayloadLength;                                        /**< The length of the response payload. */
+
+    const uint8_t * pucRequestID;                                    /**< The pointer to the request ID. */
+    uint16_t usRequestIDLength;                                      /**< The length of the request ID. */
+} AzureIoTHubClientCertificateSigningResponse_t;
+
+/**
+ * @brief Options for certificate signing requests.
+ */
+typedef struct AzureIoTHubClientCertificateSigningRequestOptions
+{
+    const uint8_t * pucReplace;   /**< Optional replace field ("*" or a specific request ID to replace). */
+    uint16_t usReplaceLength;     /**< The length of the replace field. */
+} AzureIoTHubClientCertificateSigningRequestOptions_t;
+
+/**
  * @brief Cloud message callback to be invoked when a cloud message is received in the call to AzureIoTHubClient_ProcessLoop().
  *
  * @param[in] pxMessage The #AzureIoTHubClientCloudToDeviceMessageRequest_t associated with the message.
@@ -173,6 +209,16 @@ typedef void ( * AzureIoTHubClientPropertiesCallback_t ) ( AzureIoTHubClientProp
                                                            void * pvContext );
 
 /**
+ * @brief Certificate signing callback to be invoked when a certificate signing response is received
+ *        in the call to AzureIoTHubClient_ProcessLoop().
+ *
+ * @param[in] pxResponse The #AzureIoTHubClientCertificateSigningResponse_t associated with the message.
+ * @param[in] pvContext The context passed back to the caller.
+ */
+typedef void ( * AzureIoTHubClientCertificateSigningCallback_t ) ( AzureIoTHubClientCertificateSigningResponse_t * pxResponse,
+                                                                    void * pvContext );
+
+/**
  * @brief Receive context to be used internally for the processing of messages.
  *
  * @warning Used internally.
@@ -193,6 +239,7 @@ typedef struct AzureIoTHubClientReceiveContext
             AzureIoTHubClientCloudToDeviceMessageCallback_t xCloudToDeviceMessageCallback;
             AzureIoTHubClientCommandCallback_t xCommandCallback;
             AzureIoTHubClientPropertiesCallback_t xPropertiesCallback;
+            AzureIoTHubClientCertificateSigningCallback_t xCertificateSigningCallback;
         } callbacks;
     } _internal; /**< @brief Internal to the SDK */
 } AzureIoTHubClientReceiveContext_t;
@@ -498,6 +545,52 @@ AzureIoTResult_t AzureIoTHubClient_SendPropertiesReported( AzureIoTHubClient_t *
  * @return An #AzureIoTResult_t with the result of the operation.
  */
 AzureIoTResult_t AzureIoTHubClient_RequestPropertiesAsync( AzureIoTHubClient_t * pxAzureIoTHubClient );
+
+/**
+ * @brief Subscribe to certificate signing responses.
+ *
+ * @param[in] pxAzureIoTHubClient The #AzureIoTHubClient_t * to use for this call.
+ * @param[in] xCSRCallback The #AzureIoTHubClientCertificateSigningCallback_t to invoke when certificate signing responses arrive.
+ * @param[in] prvCallbackContext A pointer to a context to pass to the callback.
+ * @param[in] ulTimeoutMilliseconds Timeout in milliseconds for Subscribe operation to complete.
+ * @return An #AzureIoTResult_t with the result of the operation.
+ */
+AzureIoTResult_t AzureIoTHubClient_SubscribeCertificateSigningResponse( AzureIoTHubClient_t * pxAzureIoTHubClient,
+                                                                         AzureIoTHubClientCertificateSigningCallback_t xCSRCallback,
+                                                                         void * prvCallbackContext,
+                                                                         uint32_t ulTimeoutMilliseconds );
+
+/**
+ * @brief Unsubscribe from certificate signing responses.
+ *
+ * @param[in] pxAzureIoTHubClient The #AzureIoTHubClient_t * to use for this call.
+ * @return An #AzureIoTResult_t with the result of the operation.
+ */
+AzureIoTResult_t AzureIoTHubClient_UnsubscribeCertificateSigningResponse( AzureIoTHubClient_t * pxAzureIoTHubClient );
+
+/**
+ * @brief Send a certificate signing request to IoT Hub.
+ *
+ * @note AzureIoTHubClient_SubscribeCertificateSigningResponse() must be called before calling this function.
+ *
+ * @param[in] pxAzureIoTHubClient The #AzureIoTHubClient_t * to use for this call.
+ * @param[in] pucCSR The pointer to the base64-encoded PKCS#10 CSR (without PEM headers).
+ * @param[in] ulCSRLength The length of the CSR.
+ * @param[in] pucRequestID The pointer to the request ID string.
+ * @param[in] usRequestIDLength The length of the request ID.
+ * @param[in] pucPayloadBuffer The buffer to use for building the JSON request payload.
+ * @param[in] ulPayloadBufferLength The length of the payload buffer.
+ * @param[in] pxOptions __[nullable]__ Optional #AzureIoTHubClientCertificateSigningRequestOptions_t for extra options (e.g., replace).
+ * @return An #AzureIoTResult_t with the result of the operation.
+ */
+AzureIoTResult_t AzureIoTHubClient_SendCertificateSigningRequest( AzureIoTHubClient_t * pxAzureIoTHubClient,
+                                                                    const uint8_t * pucCSR,
+                                                                    uint32_t ulCSRLength,
+                                                                    const uint8_t * pucRequestID,
+                                                                    uint16_t usRequestIDLength,
+                                                                    uint8_t * pucPayloadBuffer,
+                                                                    uint32_t ulPayloadBufferLength,
+                                                                    AzureIoTHubClientCertificateSigningRequestOptions_t * pxOptions );
 
 #include "azure/core/_az_cfg_suffix.h"
 

--- a/tests/ut/CMakeLists.txt
+++ b/tests/ut/CMakeLists.txt
@@ -87,6 +87,22 @@ add_cmocka_test(azure_iot_hub_client_ut
     ${CMAKE_CURRENT_LIST_DIR}
 )
 
+add_cmocka_test(azure_iot_hub_client_csr_ut
+  SOURCES
+    main.c
+    azure_iot_hub_client_csr_ut.c
+    azure_iot_cmocka_mqtt.c
+  COMPILE_OPTIONS
+    ${DEFAULT_C_COMPILE_FLAGS}
+  LINK_LIBRARIES
+    cmocka
+    az::iot_middleware::freertos
+  LINK_OPTIONS ${MOCK_LINKER_OPTIONS}
+  INCLUDE_DIRECTORIES
+    ${CMOCKA_INCLUDE_DIR}
+    ${CMAKE_CURRENT_LIST_DIR}
+)
+
 add_cmocka_test(azure_iot_hub_client_properties_ut
   SOURCES
     main.c

--- a/tests/ut/azure_iot_hub_client_csr_ut.c
+++ b/tests/ut/azure_iot_hub_client_csr_ut.c
@@ -46,6 +46,11 @@ static AzureIoTTransportInterface_t xTransportInterface =
 };
 static uint32_t ulReceivedCallbackFunctionId;
 static AzureIoTHubClientCertificateSigningResponseType_t xReceivedResponseType;
+static AzureIoTHubMessageStatus_t xReceivedMessageStatus;
+static const void * pvReceivedPayload;
+static uint32_t ulReceivedPayloadLength;
+static const uint8_t * pucReceivedRequestID;
+static uint16_t usReceivedRequestIDLength;
 /*-----------------------------------------------------------*/
 
 TickType_t xTaskGetTickCount( void );
@@ -87,6 +92,11 @@ static void prvTestCSRCallback( AzureIoTHubClientCertificateSigningResponse_t * 
     assert_true( pvContext == NULL );
 
     xReceivedResponseType = pxResponse->xResponseType;
+    xReceivedMessageStatus = pxResponse->xMessageStatus;
+    pvReceivedPayload = pxResponse->pvMessagePayload;
+    ulReceivedPayloadLength = pxResponse->ulPayloadLength;
+    pucReceivedRequestID = pxResponse->pucRequestID;
+    usReceivedRequestIDLength = pxResponse->usRequestIDLength;
     ulReceivedCallbackFunctionId = testCSR_CALLBACK_ID;
 }
 /*-----------------------------------------------------------*/
@@ -377,6 +387,7 @@ static void testAzureIoTHubClient_SendCSR_Success( void ** ppvState )
     prvSubscribeToCSR( &xTestIoTHubClient );
 
     will_return( AzureIoTMQTT_Publish, eAzureIoTMQTTSuccess );
+    usSentQOS = eAzureIoTMQTTQoS1;
     assert_int_equal( AzureIoTHubClient_SendCertificateSigningRequest( &xTestIoTHubClient,
                                                                         ( const uint8_t * ) testCSR_DATA,
                                                                         sizeof( testCSR_DATA ) - 1,
@@ -414,6 +425,11 @@ static void testAzureIoTHubClient_CSR_ReceiveAccepted_Success( void ** ppvState 
 
     assert_int_equal( ulReceivedCallbackFunctionId, testCSR_CALLBACK_ID );
     assert_int_equal( xReceivedResponseType, eAzureIoTHubClientCertificateSigningResponseAccepted );
+    assert_int_equal( xReceivedMessageStatus, eAzureIoTStatusAccepted );
+    assert_non_null( pvReceivedPayload );
+    assert_int_equal( ulReceivedPayloadLength, sizeof( testCSR_ACCEPTED_PAYLOAD ) - 1 );
+    assert_non_null( pucReceivedRequestID );
+    assert_int_equal( usReceivedRequestIDLength, sizeof( testCSR_REQUEST_ID ) - 1 );
 }
 /*-----------------------------------------------------------*/
 
@@ -443,6 +459,11 @@ static void testAzureIoTHubClient_CSR_ReceiveCompleted_Success( void ** ppvState
 
     assert_int_equal( ulReceivedCallbackFunctionId, testCSR_CALLBACK_ID );
     assert_int_equal( xReceivedResponseType, eAzureIoTHubClientCertificateSigningResponseCompleted );
+    assert_int_equal( xReceivedMessageStatus, eAzureIoTStatusOk );
+    assert_non_null( pvReceivedPayload );
+    assert_int_equal( ulReceivedPayloadLength, sizeof( testCSR_COMPLETED_PAYLOAD ) - 1 );
+    assert_non_null( pucReceivedRequestID );
+    assert_int_equal( usReceivedRequestIDLength, sizeof( testCSR_REQUEST_ID ) - 1 );
 }
 /*-----------------------------------------------------------*/
 
@@ -472,6 +493,96 @@ static void testAzureIoTHubClient_CSR_ReceiveError_Success( void ** ppvState )
 
     assert_int_equal( ulReceivedCallbackFunctionId, testCSR_CALLBACK_ID );
     assert_int_equal( xReceivedResponseType, eAzureIoTHubClientCertificateSigningResponseError );
+    assert_int_equal( xReceivedMessageStatus, eAzureIoTStatusBadRequest );
+    assert_non_null( pvReceivedPayload );
+    assert_int_equal( ulReceivedPayloadLength, sizeof( testCSR_ERROR_PAYLOAD ) - 1 );
+    assert_non_null( pucReceivedRequestID );
+    assert_int_equal( usReceivedRequestIDLength, sizeof( testCSR_REQUEST_ID ) - 1 );
+}
+/*-----------------------------------------------------------*/
+
+static void testAzureIoTHubClient_SendCSR_WithReplaceOption_Success( void ** ppvState )
+{
+    AzureIoTHubClient_t xTestIoTHubClient;
+    AzureIoTHubClientCertificateSigningRequestOptions_t xOptions =
+    {
+        .pucReplace    = ( const uint8_t * ) "*",
+        .usReplaceLength = sizeof( "*" ) - 1
+    };
+
+    ( void ) ppvState;
+
+    prvSetupTestIoTHubClient( &xTestIoTHubClient );
+    prvSubscribeToCSR( &xTestIoTHubClient );
+
+    will_return( AzureIoTMQTT_Publish, eAzureIoTMQTTSuccess );
+    usSentQOS = eAzureIoTMQTTQoS1;
+    assert_int_equal( AzureIoTHubClient_SendCertificateSigningRequest( &xTestIoTHubClient,
+                                                                        ( const uint8_t * ) testCSR_DATA,
+                                                                        sizeof( testCSR_DATA ) - 1,
+                                                                        ( const uint8_t * ) testCSR_REQUEST_ID,
+                                                                        sizeof( testCSR_REQUEST_ID ) - 1,
+                                                                        ucPayloadBuffer, sizeof( ucPayloadBuffer ),
+                                                                        &xOptions ),
+                      eAzureIoTSuccess );
+}
+/*-----------------------------------------------------------*/
+
+static void testAzureIoTHubClient_SendCSR_AfterUnsubscribe_Failure( void ** ppvState )
+{
+    AzureIoTHubClient_t xTestIoTHubClient;
+
+    ( void ) ppvState;
+
+    prvSetupTestIoTHubClient( &xTestIoTHubClient );
+    prvSubscribeToCSR( &xTestIoTHubClient );
+
+    /* Unsubscribe */
+    will_return( AzureIoTMQTT_Unsubscribe, eAzureIoTMQTTSuccess );
+    assert_int_equal( AzureIoTHubClient_UnsubscribeCertificateSigningResponse( &xTestIoTHubClient ),
+                      eAzureIoTSuccess );
+
+    /* After unsubscribing, send must fail with topic-not-subscribed */
+    assert_int_equal( AzureIoTHubClient_SendCertificateSigningRequest( &xTestIoTHubClient,
+                                                                        ( const uint8_t * ) testCSR_DATA,
+                                                                        sizeof( testCSR_DATA ) - 1,
+                                                                        ( const uint8_t * ) testCSR_REQUEST_ID,
+                                                                        sizeof( testCSR_REQUEST_ID ) - 1,
+                                                                        ucPayloadBuffer, sizeof( ucPayloadBuffer ),
+                                                                        NULL ),
+                      eAzureIoTErrorTopicNotSubscribed );
+}
+/*-----------------------------------------------------------*/
+
+static uint32_t ulTestContextValue = 0xDEADBEEF;
+
+static void prvTestCSRCallbackWithContext( AzureIoTHubClientCertificateSigningResponse_t * pxResponse,
+                                           void * pvContext )
+{
+    assert_true( pxResponse != NULL );
+    assert_true( pvContext == &ulTestContextValue );
+
+    xReceivedResponseType = pxResponse->xResponseType;
+    ulReceivedCallbackFunctionId = testCSR_CALLBACK_ID;
+}
+
+static void testAzureIoTHubClient_SubscribeCSR_WithContext_Success( void ** ppvState )
+{
+    AzureIoTHubClient_t xTestIoTHubClient;
+
+    ( void ) ppvState;
+
+    prvSetupTestIoTHubClient( &xTestIoTHubClient );
+
+    will_return( AzureIoTMQTT_Subscribe, eAzureIoTMQTTSuccess );
+    will_return( AzureIoTMQTT_ProcessLoop, eAzureIoTMQTTSuccess );
+    xPacketInfo.ucType = azureiotmqttPACKET_TYPE_SUBACK;
+    xDeserializedInfo.usPacketIdentifier = usTestPacketId;
+    ulDelayReceivePacket = 0;
+    assert_int_equal( AzureIoTHubClient_SubscribeCertificateSigningResponse( &xTestIoTHubClient,
+                                                                              prvTestCSRCallbackWithContext,
+                                                                              &ulTestContextValue, ( uint32_t ) -1 ),
+                      eAzureIoTSuccess );
 }
 /*-----------------------------------------------------------*/
 
@@ -496,6 +607,9 @@ uint32_t ulGetAllTests()
         cmocka_unit_test( testAzureIoTHubClient_CSR_ReceiveAccepted_Success ),
         cmocka_unit_test( testAzureIoTHubClient_CSR_ReceiveCompleted_Success ),
         cmocka_unit_test( testAzureIoTHubClient_CSR_ReceiveError_Success ),
+        cmocka_unit_test( testAzureIoTHubClient_SendCSR_WithReplaceOption_Success ),
+        cmocka_unit_test( testAzureIoTHubClient_SendCSR_AfterUnsubscribe_Failure ),
+        cmocka_unit_test( testAzureIoTHubClient_SubscribeCSR_WithContext_Success ),
     };
 
     return ( uint32_t ) cmocka_run_group_tests_name( "azure_iot_hub_client_csr_ut", tests, NULL, NULL );

--- a/tests/ut/azure_iot_hub_client_csr_ut.c
+++ b/tests/ut/azure_iot_hub_client_csr_ut.c
@@ -1,0 +1,503 @@
+/* Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT License. */
+
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <setjmp.h>
+
+#include <cmocka.h>
+
+#include "azure_iot_mqtt.h"
+#include "azure_iot_hub_client.h"
+/*-----------------------------------------------------------*/
+
+#define testCSR_CALLBACK_ID                         ( 4 )
+#define testCSR_ACCEPTED_MESSAGE_TOPIC              "$iothub/credentials/res/202/?$rid=1"
+#define testCSR_COMPLETED_MESSAGE_TOPIC             "$iothub/credentials/res/200/?$rid=1"
+#define testCSR_ERROR_MESSAGE_TOPIC                 "$iothub/credentials/res/400/?$rid=1"
+#define testCSR_ACCEPTED_PAYLOAD                    "{\"correlationId\":\"test-corr-id\",\"operationExpires\":\"2025-06-09T17:31:31.426Z\"}"
+#define testCSR_COMPLETED_PAYLOAD                   "test-certificate-data"
+#define testCSR_ERROR_PAYLOAD                       "{\"errorCode\":400040,\"message\":\"Credential management operation failed\"}"
+#define testCSR_DATA                                "MIICYTCCAUkCAQAwHDEaMBgGA1wRZGAw"
+#define testCSR_REQUEST_ID                          "1"
+#define testEMPTY_JSON                              "{}"
+/*-----------------------------------------------------------*/
+
+/* Data exported by cmocka port for MQTT */
+extern AzureIoTMQTTPacketInfo_t xPacketInfo;
+extern AzureIoTMQTTDeserializedInfo_t xDeserializedInfo;
+extern uint16_t usTestPacketId;
+extern const uint8_t * pucPublishPayload;
+extern uint16_t usSentQOS;
+extern uint32_t ulDelayReceivePacket;
+
+static const uint8_t ucHostname[] = "unittest.azure-devices.net";
+static const uint8_t ucDeviceId[] = "testiothub";
+static uint8_t ucBuffer[ 512 ];
+static uint8_t ucPayloadBuffer[ 512 ];
+static AzureIoTTransportInterface_t xTransportInterface =
+{
+    .pxNetworkContext = NULL,
+    .xSend            = ( AzureIoTTransportSend_t ) 0xA5A5A5A5,
+    .xRecv            = ( AzureIoTTransportRecv_t ) 0xACACACAC
+};
+static uint32_t ulReceivedCallbackFunctionId;
+static AzureIoTHubClientCertificateSigningResponseType_t xReceivedResponseType;
+/*-----------------------------------------------------------*/
+
+TickType_t xTaskGetTickCount( void );
+uint32_t ulGetAllTests();
+
+TickType_t xTaskGetTickCount( void )
+{
+    return 1;
+}
+/*-----------------------------------------------------------*/
+
+static uint64_t prvGetUnixTime( void )
+{
+    return 0xFFFFFFFFFFFFFFFF;
+}
+/*-----------------------------------------------------------*/
+
+static void prvSetupTestIoTHubClient( AzureIoTHubClient_t * pxTestIoTHubClient )
+{
+    AzureIoTHubClientOptions_t xHubClientOptions = { 0 };
+
+    will_return( AzureIoTMQTT_Init, eAzureIoTMQTTSuccess );
+    assert_int_equal( AzureIoTHubClient_Init( pxTestIoTHubClient,
+                                              ucHostname, sizeof( ucHostname ) - 1,
+                                              ucDeviceId, sizeof( ucDeviceId ) - 1,
+                                              &xHubClientOptions,
+                                              ucBuffer,
+                                              sizeof( ucBuffer ),
+                                              prvGetUnixTime,
+                                              &xTransportInterface ),
+                      eAzureIoTSuccess );
+}
+/*-----------------------------------------------------------*/
+
+static void prvTestCSRCallback( AzureIoTHubClientCertificateSigningResponse_t * pxResponse,
+                                 void * pvContext )
+{
+    assert_true( pxResponse != NULL );
+    assert_true( pvContext == NULL );
+
+    xReceivedResponseType = pxResponse->xResponseType;
+    ulReceivedCallbackFunctionId = testCSR_CALLBACK_ID;
+}
+/*-----------------------------------------------------------*/
+
+static void prvSubscribeToCSR( AzureIoTHubClient_t * pxTestIoTHubClient )
+{
+    will_return( AzureIoTMQTT_Subscribe, eAzureIoTMQTTSuccess );
+    will_return( AzureIoTMQTT_ProcessLoop, eAzureIoTMQTTSuccess );
+    xPacketInfo.ucType = azureiotmqttPACKET_TYPE_SUBACK;
+    xDeserializedInfo.usPacketIdentifier = usTestPacketId;
+    ulDelayReceivePacket = 0;
+    assert_int_equal( AzureIoTHubClient_SubscribeCertificateSigningResponse( pxTestIoTHubClient,
+                                                                              prvTestCSRCallback,
+                                                                              NULL, ( uint32_t ) -1 ),
+                      eAzureIoTSuccess );
+}
+/*-----------------------------------------------------------*/
+
+static void testAzureIoTHubClient_SubscribeCSR_InvalidArgFailure( void ** ppvState )
+{
+    AzureIoTHubClient_t xTestIoTHubClient;
+
+    ( void ) ppvState;
+
+    prvSetupTestIoTHubClient( &xTestIoTHubClient );
+
+    /* Fail subscribe when client is NULL */
+    assert_int_equal( AzureIoTHubClient_SubscribeCertificateSigningResponse( NULL,
+                                                                              prvTestCSRCallback,
+                                                                              NULL, ( uint32_t ) -1 ),
+                      eAzureIoTErrorInvalidArgument );
+
+    /* Fail subscribe when callback is NULL */
+    assert_int_equal( AzureIoTHubClient_SubscribeCertificateSigningResponse( &xTestIoTHubClient,
+                                                                              NULL,
+                                                                              NULL, ( uint32_t ) -1 ),
+                      eAzureIoTErrorInvalidArgument );
+}
+/*-----------------------------------------------------------*/
+
+static void testAzureIoTHubClient_SubscribeCSR_SubscribeFailure( void ** ppvState )
+{
+    AzureIoTHubClient_t xTestIoTHubClient;
+
+    ( void ) ppvState;
+
+    prvSetupTestIoTHubClient( &xTestIoTHubClient );
+
+    will_return( AzureIoTMQTT_Subscribe, eAzureIoTMQTTSendFailed );
+    assert_int_equal( AzureIoTHubClient_SubscribeCertificateSigningResponse( &xTestIoTHubClient,
+                                                                              prvTestCSRCallback,
+                                                                              NULL, ( uint32_t ) -1 ),
+                      eAzureIoTErrorSubscribeFailed );
+}
+/*-----------------------------------------------------------*/
+
+static void testAzureIoTHubClient_SubscribeCSR_ReceiveFailure( void ** ppvState )
+{
+    AzureIoTHubClient_t xTestIoTHubClient;
+
+    ( void ) ppvState;
+
+    prvSetupTestIoTHubClient( &xTestIoTHubClient );
+
+    will_return( AzureIoTMQTT_Subscribe, eAzureIoTMQTTSuccess );
+    will_return( AzureIoTMQTT_ProcessLoop, eAzureIoTMQTTRecvFailed );
+    assert_int_equal( AzureIoTHubClient_SubscribeCertificateSigningResponse( &xTestIoTHubClient,
+                                                                              prvTestCSRCallback,
+                                                                              NULL, ( uint32_t ) -1 ),
+                      eAzureIoTErrorFailed );
+}
+/*-----------------------------------------------------------*/
+
+static void testAzureIoTHubClient_SubscribeCSR_Success( void ** ppvState )
+{
+    AzureIoTHubClient_t xTestIoTHubClient;
+
+    ( void ) ppvState;
+
+    prvSetupTestIoTHubClient( &xTestIoTHubClient );
+
+    will_return( AzureIoTMQTT_Subscribe, eAzureIoTMQTTSuccess );
+    will_return( AzureIoTMQTT_ProcessLoop, eAzureIoTMQTTSuccess );
+    xPacketInfo.ucType = azureiotmqttPACKET_TYPE_SUBACK;
+    xDeserializedInfo.usPacketIdentifier = usTestPacketId;
+    assert_int_equal( AzureIoTHubClient_SubscribeCertificateSigningResponse( &xTestIoTHubClient,
+                                                                              prvTestCSRCallback,
+                                                                              NULL, ( uint32_t ) -1 ),
+                      eAzureIoTSuccess );
+}
+/*-----------------------------------------------------------*/
+
+static void testAzureIoTHubClient_SubscribeCSR_DelayedSuccess( void ** ppvState )
+{
+    AzureIoTHubClient_t xTestIoTHubClient;
+
+    ( void ) ppvState;
+
+    prvSetupTestIoTHubClient( &xTestIoTHubClient );
+
+    will_return( AzureIoTMQTT_Subscribe, eAzureIoTMQTTSuccess );
+    will_return_always( AzureIoTMQTT_ProcessLoop, eAzureIoTMQTTSuccess );
+    xPacketInfo.ucType = azureiotmqttPACKET_TYPE_SUBACK;
+    xDeserializedInfo.usPacketIdentifier = usTestPacketId;
+    ulDelayReceivePacket = 5 * azureiotconfigSUBACK_WAIT_INTERVAL_MS;
+    assert_int_equal( AzureIoTHubClient_SubscribeCertificateSigningResponse( &xTestIoTHubClient,
+                                                                              prvTestCSRCallback,
+                                                                              NULL, ( uint32_t ) -1 ),
+                      eAzureIoTSuccess );
+}
+/*-----------------------------------------------------------*/
+
+static void testAzureIoTHubClient_SubscribeCSR_MultipleSuccess( void ** ppvState )
+{
+    AzureIoTHubClient_t xTestIoTHubClient;
+
+    ( void ) ppvState;
+
+    prvSetupTestIoTHubClient( &xTestIoTHubClient );
+
+    for( uint32_t ulRunCount = 0; ulRunCount < 4; ulRunCount++ )
+    {
+        will_return( AzureIoTMQTT_Subscribe, eAzureIoTMQTTSuccess );
+        will_return( AzureIoTMQTT_ProcessLoop, eAzureIoTMQTTSuccess );
+        xPacketInfo.ucType = azureiotmqttPACKET_TYPE_SUBACK;
+        xDeserializedInfo.usPacketIdentifier = usTestPacketId;
+        ulDelayReceivePacket = 0;
+        assert_int_equal( AzureIoTHubClient_SubscribeCertificateSigningResponse( &xTestIoTHubClient,
+                                                                                  prvTestCSRCallback,
+                                                                                  NULL, ( uint32_t ) -1 ),
+                          eAzureIoTSuccess );
+    }
+}
+/*-----------------------------------------------------------*/
+
+static void testAzureIoTHubClient_UnsubscribeCSR_InvalidArgFailure( void ** ppvState )
+{
+    ( void ) ppvState;
+
+    assert_int_equal( AzureIoTHubClient_UnsubscribeCertificateSigningResponse( NULL ),
+                      eAzureIoTErrorInvalidArgument );
+}
+/*-----------------------------------------------------------*/
+
+static void testAzureIoTHubClient_UnsubscribeCSR_UnsubscribeFailure( void ** ppvState )
+{
+    AzureIoTHubClient_t xTestIoTHubClient;
+
+    ( void ) ppvState;
+
+    prvSetupTestIoTHubClient( &xTestIoTHubClient );
+
+    will_return( AzureIoTMQTT_Unsubscribe, eAzureIoTMQTTSendFailed );
+    assert_int_equal( AzureIoTHubClient_UnsubscribeCertificateSigningResponse( &xTestIoTHubClient ),
+                      eAzureIoTErrorUnsubscribeFailed );
+}
+/*-----------------------------------------------------------*/
+
+static void testAzureIoTHubClient_UnsubscribeCSR_Success( void ** ppvState )
+{
+    AzureIoTHubClient_t xTestIoTHubClient;
+
+    ( void ) ppvState;
+
+    prvSetupTestIoTHubClient( &xTestIoTHubClient );
+
+    will_return( AzureIoTMQTT_Unsubscribe, eAzureIoTMQTTSuccess );
+    assert_int_equal( AzureIoTHubClient_UnsubscribeCertificateSigningResponse( &xTestIoTHubClient ),
+                      eAzureIoTSuccess );
+}
+/*-----------------------------------------------------------*/
+
+static void testAzureIoTHubClient_SubUnsubCSR_Success( void ** ppvState )
+{
+    AzureIoTHubClient_t xTestIoTHubClient;
+
+    ( void ) ppvState;
+
+    prvSetupTestIoTHubClient( &xTestIoTHubClient );
+
+    /* Subscribe */
+    prvSubscribeToCSR( &xTestIoTHubClient );
+
+    /* Unsubscribe */
+    will_return( AzureIoTMQTT_Unsubscribe, eAzureIoTMQTTSuccess );
+    assert_int_equal( AzureIoTHubClient_UnsubscribeCertificateSigningResponse( &xTestIoTHubClient ),
+                      eAzureIoTSuccess );
+}
+/*-----------------------------------------------------------*/
+
+static void testAzureIoTHubClient_SendCSR_InvalidArgFailure( void ** ppvState )
+{
+    AzureIoTHubClient_t xTestIoTHubClient;
+
+    ( void ) ppvState;
+
+    prvSetupTestIoTHubClient( &xTestIoTHubClient );
+    prvSubscribeToCSR( &xTestIoTHubClient );
+
+    /* Fail when client is NULL */
+    assert_int_equal( AzureIoTHubClient_SendCertificateSigningRequest( NULL,
+                                                                        ( const uint8_t * ) testCSR_DATA,
+                                                                        sizeof( testCSR_DATA ) - 1,
+                                                                        ( const uint8_t * ) testCSR_REQUEST_ID,
+                                                                        sizeof( testCSR_REQUEST_ID ) - 1,
+                                                                        ucPayloadBuffer, sizeof( ucPayloadBuffer ),
+                                                                        NULL ),
+                      eAzureIoTErrorInvalidArgument );
+
+    /* Fail when CSR is NULL */
+    assert_int_equal( AzureIoTHubClient_SendCertificateSigningRequest( &xTestIoTHubClient,
+                                                                        NULL, 0,
+                                                                        ( const uint8_t * ) testCSR_REQUEST_ID,
+                                                                        sizeof( testCSR_REQUEST_ID ) - 1,
+                                                                        ucPayloadBuffer, sizeof( ucPayloadBuffer ),
+                                                                        NULL ),
+                      eAzureIoTErrorInvalidArgument );
+
+    /* Fail when request ID is NULL */
+    assert_int_equal( AzureIoTHubClient_SendCertificateSigningRequest( &xTestIoTHubClient,
+                                                                        ( const uint8_t * ) testCSR_DATA,
+                                                                        sizeof( testCSR_DATA ) - 1,
+                                                                        NULL, 0,
+                                                                        ucPayloadBuffer, sizeof( ucPayloadBuffer ),
+                                                                        NULL ),
+                      eAzureIoTErrorInvalidArgument );
+
+    /* Fail when payload buffer is NULL */
+    assert_int_equal( AzureIoTHubClient_SendCertificateSigningRequest( &xTestIoTHubClient,
+                                                                        ( const uint8_t * ) testCSR_DATA,
+                                                                        sizeof( testCSR_DATA ) - 1,
+                                                                        ( const uint8_t * ) testCSR_REQUEST_ID,
+                                                                        sizeof( testCSR_REQUEST_ID ) - 1,
+                                                                        NULL, 0,
+                                                                        NULL ),
+                      eAzureIoTErrorInvalidArgument );
+}
+/*-----------------------------------------------------------*/
+
+static void testAzureIoTHubClient_SendCSR_NotSubscribedFailure( void ** ppvState )
+{
+    AzureIoTHubClient_t xTestIoTHubClient;
+
+    ( void ) ppvState;
+
+    prvSetupTestIoTHubClient( &xTestIoTHubClient );
+
+    /* Send without subscribing first */
+    assert_int_equal( AzureIoTHubClient_SendCertificateSigningRequest( &xTestIoTHubClient,
+                                                                        ( const uint8_t * ) testCSR_DATA,
+                                                                        sizeof( testCSR_DATA ) - 1,
+                                                                        ( const uint8_t * ) testCSR_REQUEST_ID,
+                                                                        sizeof( testCSR_REQUEST_ID ) - 1,
+                                                                        ucPayloadBuffer, sizeof( ucPayloadBuffer ),
+                                                                        NULL ),
+                      eAzureIoTErrorTopicNotSubscribed );
+}
+/*-----------------------------------------------------------*/
+
+static void testAzureIoTHubClient_SendCSR_PublishFailure( void ** ppvState )
+{
+    AzureIoTHubClient_t xTestIoTHubClient;
+
+    ( void ) ppvState;
+
+    prvSetupTestIoTHubClient( &xTestIoTHubClient );
+    prvSubscribeToCSR( &xTestIoTHubClient );
+
+    will_return( AzureIoTMQTT_Publish, eAzureIoTMQTTSendFailed );
+    assert_int_equal( AzureIoTHubClient_SendCertificateSigningRequest( &xTestIoTHubClient,
+                                                                        ( const uint8_t * ) testCSR_DATA,
+                                                                        sizeof( testCSR_DATA ) - 1,
+                                                                        ( const uint8_t * ) testCSR_REQUEST_ID,
+                                                                        sizeof( testCSR_REQUEST_ID ) - 1,
+                                                                        ucPayloadBuffer, sizeof( ucPayloadBuffer ),
+                                                                        NULL ),
+                      eAzureIoTErrorPublishFailed );
+}
+/*-----------------------------------------------------------*/
+
+static void testAzureIoTHubClient_SendCSR_Success( void ** ppvState )
+{
+    AzureIoTHubClient_t xTestIoTHubClient;
+
+    ( void ) ppvState;
+
+    prvSetupTestIoTHubClient( &xTestIoTHubClient );
+    prvSubscribeToCSR( &xTestIoTHubClient );
+
+    will_return( AzureIoTMQTT_Publish, eAzureIoTMQTTSuccess );
+    assert_int_equal( AzureIoTHubClient_SendCertificateSigningRequest( &xTestIoTHubClient,
+                                                                        ( const uint8_t * ) testCSR_DATA,
+                                                                        sizeof( testCSR_DATA ) - 1,
+                                                                        ( const uint8_t * ) testCSR_REQUEST_ID,
+                                                                        sizeof( testCSR_REQUEST_ID ) - 1,
+                                                                        ucPayloadBuffer, sizeof( ucPayloadBuffer ),
+                                                                        NULL ),
+                      eAzureIoTSuccess );
+}
+/*-----------------------------------------------------------*/
+
+static void testAzureIoTHubClient_CSR_ReceiveAccepted_Success( void ** ppvState )
+{
+    AzureIoTHubClient_t xTestIoTHubClient;
+    AzureIoTMQTTPublishInfo_t xPublishInfo = { 0 };
+
+    ( void ) ppvState;
+
+    prvSetupTestIoTHubClient( &xTestIoTHubClient );
+    prvSubscribeToCSR( &xTestIoTHubClient );
+
+    will_return( AzureIoTMQTT_ProcessLoop, eAzureIoTMQTTSuccess );
+    xPacketInfo.ucType = azureiotmqttPACKET_TYPE_PUBLISH;
+    xDeserializedInfo.usPacketIdentifier = 1;
+    xPublishInfo.pcTopicName = testCSR_ACCEPTED_MESSAGE_TOPIC;
+    xPublishInfo.usTopicNameLength = sizeof( testCSR_ACCEPTED_MESSAGE_TOPIC ) - 1;
+    xPublishInfo.pvPayload = ( const void * ) testCSR_ACCEPTED_PAYLOAD;
+    xPublishInfo.xPayloadLength = sizeof( testCSR_ACCEPTED_PAYLOAD ) - 1;
+    xDeserializedInfo.pxPublishInfo = &xPublishInfo;
+    ulReceivedCallbackFunctionId = 0;
+    xReceivedResponseType = 0;
+
+    assert_int_equal( AzureIoTHubClient_ProcessLoop( &xTestIoTHubClient, 60 ),
+                      eAzureIoTSuccess );
+
+    assert_int_equal( ulReceivedCallbackFunctionId, testCSR_CALLBACK_ID );
+    assert_int_equal( xReceivedResponseType, eAzureIoTHubClientCertificateSigningResponseAccepted );
+}
+/*-----------------------------------------------------------*/
+
+static void testAzureIoTHubClient_CSR_ReceiveCompleted_Success( void ** ppvState )
+{
+    AzureIoTHubClient_t xTestIoTHubClient;
+    AzureIoTMQTTPublishInfo_t xPublishInfo = { 0 };
+
+    ( void ) ppvState;
+
+    prvSetupTestIoTHubClient( &xTestIoTHubClient );
+    prvSubscribeToCSR( &xTestIoTHubClient );
+
+    will_return( AzureIoTMQTT_ProcessLoop, eAzureIoTMQTTSuccess );
+    xPacketInfo.ucType = azureiotmqttPACKET_TYPE_PUBLISH;
+    xDeserializedInfo.usPacketIdentifier = 1;
+    xPublishInfo.pcTopicName = testCSR_COMPLETED_MESSAGE_TOPIC;
+    xPublishInfo.usTopicNameLength = sizeof( testCSR_COMPLETED_MESSAGE_TOPIC ) - 1;
+    xPublishInfo.pvPayload = ( const void * ) testCSR_COMPLETED_PAYLOAD;
+    xPublishInfo.xPayloadLength = sizeof( testCSR_COMPLETED_PAYLOAD ) - 1;
+    xDeserializedInfo.pxPublishInfo = &xPublishInfo;
+    ulReceivedCallbackFunctionId = 0;
+    xReceivedResponseType = 0;
+
+    assert_int_equal( AzureIoTHubClient_ProcessLoop( &xTestIoTHubClient, 60 ),
+                      eAzureIoTSuccess );
+
+    assert_int_equal( ulReceivedCallbackFunctionId, testCSR_CALLBACK_ID );
+    assert_int_equal( xReceivedResponseType, eAzureIoTHubClientCertificateSigningResponseCompleted );
+}
+/*-----------------------------------------------------------*/
+
+static void testAzureIoTHubClient_CSR_ReceiveError_Success( void ** ppvState )
+{
+    AzureIoTHubClient_t xTestIoTHubClient;
+    AzureIoTMQTTPublishInfo_t xPublishInfo = { 0 };
+
+    ( void ) ppvState;
+
+    prvSetupTestIoTHubClient( &xTestIoTHubClient );
+    prvSubscribeToCSR( &xTestIoTHubClient );
+
+    will_return( AzureIoTMQTT_ProcessLoop, eAzureIoTMQTTSuccess );
+    xPacketInfo.ucType = azureiotmqttPACKET_TYPE_PUBLISH;
+    xDeserializedInfo.usPacketIdentifier = 1;
+    xPublishInfo.pcTopicName = testCSR_ERROR_MESSAGE_TOPIC;
+    xPublishInfo.usTopicNameLength = sizeof( testCSR_ERROR_MESSAGE_TOPIC ) - 1;
+    xPublishInfo.pvPayload = ( const void * ) testCSR_ERROR_PAYLOAD;
+    xPublishInfo.xPayloadLength = sizeof( testCSR_ERROR_PAYLOAD ) - 1;
+    xDeserializedInfo.pxPublishInfo = &xPublishInfo;
+    ulReceivedCallbackFunctionId = 0;
+    xReceivedResponseType = 0;
+
+    assert_int_equal( AzureIoTHubClient_ProcessLoop( &xTestIoTHubClient, 60 ),
+                      eAzureIoTSuccess );
+
+    assert_int_equal( ulReceivedCallbackFunctionId, testCSR_CALLBACK_ID );
+    assert_int_equal( xReceivedResponseType, eAzureIoTHubClientCertificateSigningResponseError );
+}
+/*-----------------------------------------------------------*/
+
+uint32_t ulGetAllTests()
+{
+    const struct CMUnitTest tests[] =
+    {
+        cmocka_unit_test( testAzureIoTHubClient_SubscribeCSR_InvalidArgFailure ),
+        cmocka_unit_test( testAzureIoTHubClient_SubscribeCSR_SubscribeFailure ),
+        cmocka_unit_test( testAzureIoTHubClient_SubscribeCSR_ReceiveFailure ),
+        cmocka_unit_test( testAzureIoTHubClient_SubscribeCSR_Success ),
+        cmocka_unit_test( testAzureIoTHubClient_SubscribeCSR_DelayedSuccess ),
+        cmocka_unit_test( testAzureIoTHubClient_SubscribeCSR_MultipleSuccess ),
+        cmocka_unit_test( testAzureIoTHubClient_UnsubscribeCSR_InvalidArgFailure ),
+        cmocka_unit_test( testAzureIoTHubClient_UnsubscribeCSR_UnsubscribeFailure ),
+        cmocka_unit_test( testAzureIoTHubClient_UnsubscribeCSR_Success ),
+        cmocka_unit_test( testAzureIoTHubClient_SubUnsubCSR_Success ),
+        cmocka_unit_test( testAzureIoTHubClient_SendCSR_InvalidArgFailure ),
+        cmocka_unit_test( testAzureIoTHubClient_SendCSR_NotSubscribedFailure ),
+        cmocka_unit_test( testAzureIoTHubClient_SendCSR_PublishFailure ),
+        cmocka_unit_test( testAzureIoTHubClient_SendCSR_Success ),
+        cmocka_unit_test( testAzureIoTHubClient_CSR_ReceiveAccepted_Success ),
+        cmocka_unit_test( testAzureIoTHubClient_CSR_ReceiveCompleted_Success ),
+        cmocka_unit_test( testAzureIoTHubClient_CSR_ReceiveError_Success ),
+    };
+
+    return ( uint32_t ) cmocka_run_group_tests_name( "azure_iot_hub_client_csr_ut", tests, NULL, NULL );
+}
+/*-----------------------------------------------------------*/

--- a/tests/ut/azure_iot_hub_client_csr_ut.c
+++ b/tests/ut/azure_iot_hub_client_csr_ut.c
@@ -302,8 +302,8 @@ static void testAzureIoTHubClient_SendCSR_InvalidArgFailure( void ** ppvState )
                                                                         sizeof( testCSR_DATA ) - 1,
                                                                         ( const uint8_t * ) testCSR_REQUEST_ID,
                                                                         sizeof( testCSR_REQUEST_ID ) - 1,
-                                                                        ucPayloadBuffer, sizeof( ucPayloadBuffer ),
-                                                                        NULL ),
+                                                                        NULL,
+                                                                        ucPayloadBuffer, sizeof( ucPayloadBuffer ) ),
                       eAzureIoTErrorInvalidArgument );
 
     /* Fail when CSR is NULL */
@@ -311,8 +311,8 @@ static void testAzureIoTHubClient_SendCSR_InvalidArgFailure( void ** ppvState )
                                                                         NULL, 0,
                                                                         ( const uint8_t * ) testCSR_REQUEST_ID,
                                                                         sizeof( testCSR_REQUEST_ID ) - 1,
-                                                                        ucPayloadBuffer, sizeof( ucPayloadBuffer ),
-                                                                        NULL ),
+                                                                        NULL,
+                                                                        ucPayloadBuffer, sizeof( ucPayloadBuffer ) ),
                       eAzureIoTErrorInvalidArgument );
 
     /* Fail when request ID is NULL */
@@ -320,8 +320,8 @@ static void testAzureIoTHubClient_SendCSR_InvalidArgFailure( void ** ppvState )
                                                                         ( const uint8_t * ) testCSR_DATA,
                                                                         sizeof( testCSR_DATA ) - 1,
                                                                         NULL, 0,
-                                                                        ucPayloadBuffer, sizeof( ucPayloadBuffer ),
-                                                                        NULL ),
+                                                                        NULL,
+                                                                        ucPayloadBuffer, sizeof( ucPayloadBuffer ) ),
                       eAzureIoTErrorInvalidArgument );
 
     /* Fail when payload buffer is NULL */
@@ -330,8 +330,8 @@ static void testAzureIoTHubClient_SendCSR_InvalidArgFailure( void ** ppvState )
                                                                         sizeof( testCSR_DATA ) - 1,
                                                                         ( const uint8_t * ) testCSR_REQUEST_ID,
                                                                         sizeof( testCSR_REQUEST_ID ) - 1,
-                                                                        NULL, 0,
-                                                                        NULL ),
+                                                                        NULL,
+                                                                        NULL, 0 ),
                       eAzureIoTErrorInvalidArgument );
 }
 /*-----------------------------------------------------------*/
@@ -350,8 +350,8 @@ static void testAzureIoTHubClient_SendCSR_NotSubscribedFailure( void ** ppvState
                                                                         sizeof( testCSR_DATA ) - 1,
                                                                         ( const uint8_t * ) testCSR_REQUEST_ID,
                                                                         sizeof( testCSR_REQUEST_ID ) - 1,
-                                                                        ucPayloadBuffer, sizeof( ucPayloadBuffer ),
-                                                                        NULL ),
+                                                                        NULL,
+                                                                        ucPayloadBuffer, sizeof( ucPayloadBuffer ) ),
                       eAzureIoTErrorTopicNotSubscribed );
 }
 /*-----------------------------------------------------------*/
@@ -371,8 +371,8 @@ static void testAzureIoTHubClient_SendCSR_PublishFailure( void ** ppvState )
                                                                         sizeof( testCSR_DATA ) - 1,
                                                                         ( const uint8_t * ) testCSR_REQUEST_ID,
                                                                         sizeof( testCSR_REQUEST_ID ) - 1,
-                                                                        ucPayloadBuffer, sizeof( ucPayloadBuffer ),
-                                                                        NULL ),
+                                                                        NULL,
+                                                                        ucPayloadBuffer, sizeof( ucPayloadBuffer ) ),
                       eAzureIoTErrorPublishFailed );
 }
 /*-----------------------------------------------------------*/
@@ -393,8 +393,8 @@ static void testAzureIoTHubClient_SendCSR_Success( void ** ppvState )
                                                                         sizeof( testCSR_DATA ) - 1,
                                                                         ( const uint8_t * ) testCSR_REQUEST_ID,
                                                                         sizeof( testCSR_REQUEST_ID ) - 1,
-                                                                        ucPayloadBuffer, sizeof( ucPayloadBuffer ),
-                                                                        NULL ),
+                                                                        NULL,
+                                                                        ucPayloadBuffer, sizeof( ucPayloadBuffer ) ),
                       eAzureIoTSuccess );
 }
 /*-----------------------------------------------------------*/
@@ -522,8 +522,8 @@ static void testAzureIoTHubClient_SendCSR_WithReplaceOption_Success( void ** ppv
                                                                         sizeof( testCSR_DATA ) - 1,
                                                                         ( const uint8_t * ) testCSR_REQUEST_ID,
                                                                         sizeof( testCSR_REQUEST_ID ) - 1,
-                                                                        ucPayloadBuffer, sizeof( ucPayloadBuffer ),
-                                                                        &xOptions ),
+                                                                        &xOptions,
+                                                                        ucPayloadBuffer, sizeof( ucPayloadBuffer ) ),
                       eAzureIoTSuccess );
 }
 /*-----------------------------------------------------------*/
@@ -548,8 +548,8 @@ static void testAzureIoTHubClient_SendCSR_AfterUnsubscribe_Failure( void ** ppvS
                                                                         sizeof( testCSR_DATA ) - 1,
                                                                         ( const uint8_t * ) testCSR_REQUEST_ID,
                                                                         sizeof( testCSR_REQUEST_ID ) - 1,
-                                                                        ucPayloadBuffer, sizeof( ucPayloadBuffer ),
-                                                                        NULL ),
+                                                                        NULL,
+                                                                        ucPayloadBuffer, sizeof( ucPayloadBuffer ) ),
                       eAzureIoTErrorTopicNotSubscribed );
 }
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
This pull request adds support for certificate signing requests (CSR) and responses in the Azure IoT Hub client, enabling devices to request certificate signing from the IoT Hub and handle responses asynchronously. It introduces new APIs, types, and callbacks for managing the CSR workflow, updates internal structures to support this feature, and adds corresponding unit tests.

**Certificate Signing Request (CSR) Feature Additions:**

* Introduced new APIs in `azure_iot_hub_client.h` and their implementations in `azure_iot_hub_client.c` for subscribing to certificate signing responses, unsubscribing, and sending certificate signing requests: `AzureIoTHubClient_SubscribeCertificateSigningResponse`, `AzureIoTHubClient_UnsubscribeCertificateSigningResponse`, and `AzureIoTHubClient_SendCertificateSigningRequest`. [[1]](diffhunk://#diff-0e120e10ebcb56142778d40f007593574f2c64097e828097586b4377b078092aR551-R601) [[2]](diffhunk://#diff-9851b36fad051943e3ad848d9b1c02a2b3dda336f8214ac9b1271f060f7910ecR1486-R1674)
* Added new types and enums to represent CSR request options and response types: `AzureIoTHubClientCertificateSigningResponseType_t`, `AzureIoTHubClientCertificateSigningResponse_t`, and `AzureIoTHubClientCertificateSigningRequestOptions_t`. Also added a callback type for CSR responses. [[1]](diffhunk://#diff-0e120e10ebcb56142778d40f007593574f2c64097e828097586b4377b078092aR148-R184) [[2]](diffhunk://#diff-0e120e10ebcb56142778d40f007593574f2c64097e828097586b4377b078092aR213-R222)
* Updated the message type enum to include certificate signing responses (`eAzureIoTHubCertificateSigningMessage`).

**Internal Structure and Processing Updates:**

* Extended the receive context and feature count to handle CSR messages, including a new index (`azureiothubRECEIVE_CONTEXT_INDEX_CSR`) and callback storage. [[1]](diffhunk://#diff-9851b36fad051943e3ad848d9b1c02a2b3dda336f8214ac9b1271f060f7910ecR53) [[2]](diffhunk://#diff-0e120e10ebcb56142778d40f007593574f2c64097e828097586b4377b078092aL35-R35) [[3]](diffhunk://#diff-0e120e10ebcb56142778d40f007593574f2c64097e828097586b4377b078092aR244)
* Implemented internal processing for incoming CSR responses (`prvAzureIoTHubClientCSRProcess`).

**Testing Enhancements:**

* Added a new unit test target `azure_iot_hub_client_csr_ut` to cover the CSR functionality.

**Dependency Update:**

* Updated the Azure SDK for C submodule to the latest commit.