### PR TITLE
Align DPS and IoT Hub CSR APIs

### DIFF
--- a/source/azure_iot_hub_client.c
+++ b/source/azure_iot_hub_client.c
@@ -423,6 +423,24 @@ static uint32_t prvAzureIoTHubClientCSRProcess( AzureIoTHubClientReceiveContext_
             xCSRResponse.pucRequestID = az_span_ptr( xOutResponseInfo.request_id );
             xCSRResponse.usRequestIDLength = ( uint16_t ) az_span_size( xOutResponseInfo.request_id );
 
+            if( xOutResponseInfo.response_type == AZ_IOT_HUB_CLIENT_CERTIFICATE_SIGNING_RESPONSE_TYPE_COMPLETED )
+            {
+                az_span xPayloadSpan = az_span_create(
+                    ( uint8_t * ) xMQTTPublishInfo->pvPayload,
+                    ( int32_t ) xMQTTPublishInfo->xPayloadLength );
+
+                az_result xParseResult = az_iot_hub_client_certificate_signing_request_parse_completed_response(
+                    &pxAzureIoTHubClient->_internal.xAzureIoTHubClientCore,
+                    xPayloadSpan,
+                    &pxAzureIoTHubClient->_internal.xCSRCompletedResponse );
+
+                if( az_result_failed( xParseResult ) )
+                {
+                    AZLogError( ( "Failed to parse CSR completed response payload" ) );
+                    pxAzureIoTHubClient->_internal.xCSRCompletedResponse.issued_certificate_chain_count = 0;
+                }
+            }
+
             AZLogDebug( ( "Invoking certificate signing callback" ) );
             pxContext->_internal.callbacks.xCertificateSigningCallback( &xCSRResponse,
                                                                         pxContext->_internal.pvCallbackContext );
@@ -1666,6 +1684,74 @@ AzureIoTResult_t AzureIoTHubClient_SendCertificateSigningRequest( AzureIoTHubCli
             {
                 xResult = eAzureIoTSuccess;
             }
+        }
+    }
+
+    return xResult;
+}
+/*-----------------------------------------------------------*/
+
+AzureIoTResult_t AzureIoTHubClient_GetIssuedCertificateChainLength(
+    AzureIoTHubClient_t * pxAzureIoTHubClient,
+    uint32_t * pulIssuedCertificateChainLength )
+{
+    AzureIoTResult_t xResult;
+
+    if( ( pxAzureIoTHubClient == NULL ) || ( pulIssuedCertificateChainLength == NULL ) )
+    {
+        AZLogError( ( "AzureIoTHubClient_GetIssuedCertificateChainLength failed: invalid argument" ) );
+        xResult = eAzureIoTErrorInvalidArgument;
+    }
+    else
+    {
+        *pulIssuedCertificateChainLength =
+            pxAzureIoTHubClient->_internal.xCSRCompletedResponse.issued_certificate_chain_count;
+
+        xResult = eAzureIoTSuccess;
+    }
+
+    return xResult;
+}
+/*-----------------------------------------------------------*/
+
+AzureIoTResult_t AzureIoTHubClient_GetIssuedCertificate(
+    AzureIoTHubClient_t * pxAzureIoTHubClient,
+    uint32_t ulCertificatePositionNumber,
+    uint8_t * pucIssuedCertificate,
+    uint32_t * pulIssuedCertificateLength )
+{
+    AzureIoTResult_t xResult;
+    az_span * pxCertificate;
+    uint32_t ulCertificateLength;
+
+    if( ( pxAzureIoTHubClient == NULL ) ||
+        ( pucIssuedCertificate == NULL ) || ( pulIssuedCertificateLength == NULL ) )
+    {
+        AZLogError( ( "AzureIoTHubClient_GetIssuedCertificate failed: invalid argument" ) );
+        xResult = eAzureIoTErrorInvalidArgument;
+    }
+    else if( ulCertificatePositionNumber >=
+             pxAzureIoTHubClient->_internal.xCSRCompletedResponse.issued_certificate_chain_count )
+    {
+        AZLogError( ( "AzureIoTHubClient_GetIssuedCertificate failed: position out of bounds" ) );
+        xResult = eAzureIoTErrorInvalidArgument;
+    }
+    else
+    {
+        pxCertificate = &pxAzureIoTHubClient->_internal.xCSRCompletedResponse
+                             .issued_certificate_chain[ ulCertificatePositionNumber ];
+        ulCertificateLength = ( uint32_t ) az_span_size( *pxCertificate );
+
+        if( *pulIssuedCertificateLength < ulCertificateLength )
+        {
+            AZLogError( ( "AzureIoTHubClient_GetIssuedCertificate failed: buffer too small" ) );
+            xResult = eAzureIoTErrorFailed;
+        }
+        else
+        {
+            memcpy( pucIssuedCertificate, az_span_ptr( *pxCertificate ), ulCertificateLength );
+            *pulIssuedCertificateLength = ulCertificateLength;
+            xResult = eAzureIoTSuccess;
         }
     }
 

--- a/source/include/azure_iot_hub_client.h
+++ b/source/include/azure_iot_hub_client.h
@@ -311,6 +311,8 @@ struct AzureIoTHubClient
         uint32_t ulCurrentPropertyRequestID;
 
         AzureIoTHubClientReceiveContext_t xReceiveContext[ azureiothubSUBSCRIBE_FEATURE_COUNT ];
+
+        az_iot_hub_client_certificate_signing_completed_response xCSRCompletedResponse;
     }
     _internal; /**< @brief Internal to the SDK */
 };
@@ -598,6 +600,43 @@ AzureIoTResult_t AzureIoTHubClient_SendCertificateSigningRequest( AzureIoTHubCli
                                                                     const AzureIoTHubClientCertificateSigningRequestOptions_t * pxOptions,
                                                                     uint8_t * pucPayloadBuffer,
                                                                     uint32_t ulPayloadBufferLength );
+
+/**
+ * @brief Get the number of certificates in the issued certificate chain from the last CSR response.
+ *
+ * @note Must be called after receiving a 200 Completed CSR response and before the
+ *       next AzureIoTHubClient_ProcessLoop() call (the internal spans reference the MQTT buffer).
+ *
+ * @param[in] pxAzureIoTHubClient The #AzureIoTHubClient_t * to use for this call.
+ * @param[out] pulIssuedCertificateChainLength The pointer to the `uint32_t` which will be populated
+ *             with the number of issued certificates.
+ * @return An #AzureIoTResult_t with the result of the operation.
+ */
+AzureIoTResult_t AzureIoTHubClient_GetIssuedCertificateChainLength(
+    AzureIoTHubClient_t * pxAzureIoTHubClient,
+    uint32_t * pulIssuedCertificateChainLength );
+
+/**
+ * @brief Get a certificate from the issued certificate chain at the given position.
+ *
+ * @note The certificate data is base64-encoded DER (not PEM). The caller is
+ *       responsible for any conversion (e.g., wrapping with PEM headers).
+ * @note Must be called after receiving a 200 Completed CSR response and before the
+ *       next AzureIoTHubClient_ProcessLoop() call.
+ *
+ * @param[in] pxAzureIoTHubClient The #AzureIoTHubClient_t * to use for this call.
+ * @param[in] ulCertificatePositionNumber The index of the certificate in the issued chain.
+ * @param[out] pucIssuedCertificate The pointer to a buffer which will be populated with the
+ *             issued certificate data.
+ * @param[in,out] pulIssuedCertificateLength On input, the size of \p pucIssuedCertificate buffer.
+ *                On output, the length of the certificate data written.
+ * @return An #AzureIoTResult_t with the result of the operation.
+ */
+AzureIoTResult_t AzureIoTHubClient_GetIssuedCertificate(
+    AzureIoTHubClient_t * pxAzureIoTHubClient,
+    uint32_t ulCertificatePositionNumber,
+    uint8_t * pucIssuedCertificate,
+    uint32_t * pulIssuedCertificateLength );
 
 #include "azure/core/_az_cfg_suffix.h"
 

--- a/tests/ut/azure_iot_hub_client_csr_ut.c
+++ b/tests/ut/azure_iot_hub_client_csr_ut.c
@@ -19,7 +19,7 @@
 #define testCSR_COMPLETED_MESSAGE_TOPIC             "$iothub/credentials/res/200/?$rid=1"
 #define testCSR_ERROR_MESSAGE_TOPIC                 "$iothub/credentials/res/400/?$rid=1"
 #define testCSR_ACCEPTED_PAYLOAD                    "{\"correlationId\":\"test-corr-id\",\"operationExpires\":\"2025-06-09T17:31:31.426Z\"}"
-#define testCSR_COMPLETED_PAYLOAD                   "test-certificate-data"
+#define testCSR_COMPLETED_PAYLOAD                   "[\"ROOT CERT\",\"INTERMEDIATE CERT\",\"LEAF CERT\"]"
 #define testCSR_ERROR_PAYLOAD                       "{\"errorCode\":400040,\"message\":\"Credential management operation failed\"}"
 #define testCSR_DATA                                "MIICYTCCAUkCAQAwHDEaMBgGA1wRZGAw"
 #define testCSR_REQUEST_ID                          "1"
@@ -464,6 +464,37 @@ static void testAzureIoTHubClient_CSR_ReceiveCompleted_Success( void ** ppvState
     assert_int_equal( ulReceivedPayloadLength, sizeof( testCSR_COMPLETED_PAYLOAD ) - 1 );
     assert_non_null( pucReceivedRequestID );
     assert_int_equal( usReceivedRequestIDLength, sizeof( testCSR_REQUEST_ID ) - 1 );
+
+    /* Verify accessor functions return parsed certificates */
+    uint32_t ulChainLength = 0;
+    assert_int_equal( AzureIoTHubClient_GetIssuedCertificateChainLength(
+                          &xTestIoTHubClient, &ulChainLength ),
+                      eAzureIoTSuccess );
+    assert_int_equal( ulChainLength, 3 );
+
+    uint8_t ucCertBuf[ 64 ];
+    uint32_t ulCertLen;
+
+    ulCertLen = sizeof( ucCertBuf );
+    assert_int_equal( AzureIoTHubClient_GetIssuedCertificate(
+                          &xTestIoTHubClient, 0, ucCertBuf, &ulCertLen ),
+                      eAzureIoTSuccess );
+    assert_int_equal( ulCertLen, sizeof( "ROOT CERT" ) - 1 );
+    assert_memory_equal( ucCertBuf, "ROOT CERT", ulCertLen );
+
+    ulCertLen = sizeof( ucCertBuf );
+    assert_int_equal( AzureIoTHubClient_GetIssuedCertificate(
+                          &xTestIoTHubClient, 1, ucCertBuf, &ulCertLen ),
+                      eAzureIoTSuccess );
+    assert_int_equal( ulCertLen, sizeof( "INTERMEDIATE CERT" ) - 1 );
+    assert_memory_equal( ucCertBuf, "INTERMEDIATE CERT", ulCertLen );
+
+    ulCertLen = sizeof( ucCertBuf );
+    assert_int_equal( AzureIoTHubClient_GetIssuedCertificate(
+                          &xTestIoTHubClient, 2, ucCertBuf, &ulCertLen ),
+                      eAzureIoTSuccess );
+    assert_int_equal( ulCertLen, sizeof( "LEAF CERT" ) - 1 );
+    assert_memory_equal( ucCertBuf, "LEAF CERT", ulCertLen );
 }
 /*-----------------------------------------------------------*/
 
@@ -586,6 +617,113 @@ static void testAzureIoTHubClient_SubscribeCSR_WithContext_Success( void ** ppvS
 }
 /*-----------------------------------------------------------*/
 
+static void testAzureIoTHubClient_GetCertChainLength_InvalidArg( void ** ppvState )
+{
+    AzureIoTHubClient_t xTestIoTHubClient;
+    uint32_t ulLength;
+
+    ( void ) ppvState;
+
+    prvSetupTestIoTHubClient( &xTestIoTHubClient );
+
+    /* NULL client */
+    assert_int_equal( AzureIoTHubClient_GetIssuedCertificateChainLength( NULL, &ulLength ),
+                      eAzureIoTErrorInvalidArgument );
+
+    /* NULL output */
+    assert_int_equal( AzureIoTHubClient_GetIssuedCertificateChainLength( &xTestIoTHubClient, NULL ),
+                      eAzureIoTErrorInvalidArgument );
+}
+/*-----------------------------------------------------------*/
+
+static void testAzureIoTHubClient_GetCertChainLength_ZeroBeforeCSR( void ** ppvState )
+{
+    AzureIoTHubClient_t xTestIoTHubClient;
+    uint32_t ulLength = 99;
+
+    ( void ) ppvState;
+
+    prvSetupTestIoTHubClient( &xTestIoTHubClient );
+
+    assert_int_equal( AzureIoTHubClient_GetIssuedCertificateChainLength( &xTestIoTHubClient, &ulLength ),
+                      eAzureIoTSuccess );
+    assert_int_equal( ulLength, 0 );
+}
+/*-----------------------------------------------------------*/
+
+static void testAzureIoTHubClient_GetCert_InvalidArg( void ** ppvState )
+{
+    AzureIoTHubClient_t xTestIoTHubClient;
+    uint8_t ucBuf[ 64 ];
+    uint32_t ulLen = sizeof( ucBuf );
+
+    ( void ) ppvState;
+
+    prvSetupTestIoTHubClient( &xTestIoTHubClient );
+
+    /* NULL client */
+    assert_int_equal( AzureIoTHubClient_GetIssuedCertificate( NULL, 0, ucBuf, &ulLen ),
+                      eAzureIoTErrorInvalidArgument );
+
+    /* NULL certificate buffer */
+    assert_int_equal( AzureIoTHubClient_GetIssuedCertificate( &xTestIoTHubClient, 0, NULL, &ulLen ),
+                      eAzureIoTErrorInvalidArgument );
+
+    /* NULL length */
+    assert_int_equal( AzureIoTHubClient_GetIssuedCertificate( &xTestIoTHubClient, 0, ucBuf, NULL ),
+                      eAzureIoTErrorInvalidArgument );
+}
+/*-----------------------------------------------------------*/
+
+static void testAzureIoTHubClient_GetCert_OutOfBounds( void ** ppvState )
+{
+    AzureIoTHubClient_t xTestIoTHubClient;
+    uint8_t ucBuf[ 64 ];
+    uint32_t ulLen = sizeof( ucBuf );
+
+    ( void ) ppvState;
+
+    prvSetupTestIoTHubClient( &xTestIoTHubClient );
+
+    /* No CSR response yet, count is 0, so index 0 should be out of bounds */
+    assert_int_equal( AzureIoTHubClient_GetIssuedCertificate( &xTestIoTHubClient, 0, ucBuf, &ulLen ),
+                      eAzureIoTErrorInvalidArgument );
+}
+/*-----------------------------------------------------------*/
+
+static void testAzureIoTHubClient_GetCert_BufferTooSmall( void ** ppvState )
+{
+    AzureIoTHubClient_t xTestIoTHubClient;
+    AzureIoTMQTTPublishInfo_t xPublishInfo = { 0 };
+    uint8_t ucBuf[ 2 ];
+    uint32_t ulLen;
+
+    ( void ) ppvState;
+
+    prvSetupTestIoTHubClient( &xTestIoTHubClient );
+    prvSubscribeToCSR( &xTestIoTHubClient );
+
+    /* Receive a completed response to populate certs */
+    will_return( AzureIoTMQTT_ProcessLoop, eAzureIoTMQTTSuccess );
+    xPacketInfo.ucType = azureiotmqttPACKET_TYPE_PUBLISH;
+    xDeserializedInfo.usPacketIdentifier = 1;
+    xPublishInfo.pcTopicName = testCSR_COMPLETED_MESSAGE_TOPIC;
+    xPublishInfo.usTopicNameLength = sizeof( testCSR_COMPLETED_MESSAGE_TOPIC ) - 1;
+    xPublishInfo.pvPayload = ( const void * ) testCSR_COMPLETED_PAYLOAD;
+    xPublishInfo.xPayloadLength = sizeof( testCSR_COMPLETED_PAYLOAD ) - 1;
+    xDeserializedInfo.pxPublishInfo = &xPublishInfo;
+    ulReceivedCallbackFunctionId = 0;
+
+    assert_int_equal( AzureIoTHubClient_ProcessLoop( &xTestIoTHubClient, 60 ),
+                      eAzureIoTSuccess );
+
+    /* Buffer too small for "ROOT CERT" (9 bytes) */
+    ulLen = sizeof( ucBuf );
+    assert_int_equal( AzureIoTHubClient_GetIssuedCertificate( &xTestIoTHubClient, 0, ucBuf, &ulLen ),
+                      eAzureIoTErrorFailed );
+}
+/*-----------------------------------------------------------*/
+
 uint32_t ulGetAllTests()
 {
     const struct CMUnitTest tests[] =
@@ -610,6 +748,11 @@ uint32_t ulGetAllTests()
         cmocka_unit_test( testAzureIoTHubClient_SendCSR_WithReplaceOption_Success ),
         cmocka_unit_test( testAzureIoTHubClient_SendCSR_AfterUnsubscribe_Failure ),
         cmocka_unit_test( testAzureIoTHubClient_SubscribeCSR_WithContext_Success ),
+        cmocka_unit_test( testAzureIoTHubClient_GetCertChainLength_InvalidArg ),
+        cmocka_unit_test( testAzureIoTHubClient_GetCertChainLength_ZeroBeforeCSR ),
+        cmocka_unit_test( testAzureIoTHubClient_GetCert_InvalidArg ),
+        cmocka_unit_test( testAzureIoTHubClient_GetCert_OutOfBounds ),
+        cmocka_unit_test( testAzureIoTHubClient_GetCert_BufferTooSmall ),
     };
 
     return ( uint32_t ) cmocka_run_group_tests_name( "azure_iot_hub_client_csr_ut", tests, NULL, NULL );


### PR DESCRIPTION
## Summary
Aligns the IoT Hub CSR API with the existing DPS Provisioning CSR API by adding certificate chain accessor functions to `AzureIoTHubClient`.

The DPS Provisioning client already exposes `GetIssuedCertificateChainLength` and `GetIssuedCertificate` for retrieving issued certificates after a CSR flow completes. The IoT Hub client was missing equivalent functionality — callers received the raw CSR response payload but had no structured way to extract individual certificates from the chain.

## Changes
This PR closes that gap by:
- Parsing the completed CSR response internally and storing the result in `xCSRCompletedResponse`
- Adding `AzureIoTHubClient_GetIssuedCertificateChainLength` and `AzureIoTHubClient_GetIssuedCertificate` with the same signatures and semantics as their DPS counterparts
- Adding unit tests covering normal operation, invalid arguments, out-of-bounds access, and buffer size validation