### PR TITLE
code_style.sh applied

### DIFF
--- a/.github/workflows/ci_tests_linux.yml
+++ b/.github/workflows/ci_tests_linux.yml
@@ -6,7 +6,7 @@ on:
       - main
   pull_request:
   pull_request_target:
-    types: [labeled]
+    types: [opened, synchronize, reopened, labeled]
   workflow_dispatch:
 jobs:
   build:

--- a/source/azure_iot_hub_client.c
+++ b/source/azure_iot_hub_client.c
@@ -387,8 +387,8 @@ static uint32_t prvAzureIoTHubClientPropertiesProcess( AzureIoTHubClientReceiveC
  *
  * */
 static uint32_t prvAzureIoTHubClientCSRProcess( AzureIoTHubClientReceiveContext_t * pxContext,
-                                                 AzureIoTHubClient_t * pxAzureIoTHubClient,
-                                                 void * pvPublishInfo )
+                                                AzureIoTHubClient_t * pxAzureIoTHubClient,
+                                                void * pvPublishInfo )
 {
     AzureIoTResult_t xResult;
     AzureIoTHubClientCertificateSigningResponse_t xCSRResponse = { 0 };
@@ -1503,9 +1503,9 @@ AzureIoTResult_t AzureIoTHubClient_RequestPropertiesAsync( AzureIoTHubClient_t *
 /*-----------------------------------------------------------*/
 
 AzureIoTResult_t AzureIoTHubClient_SubscribeCertificateSigningResponse( AzureIoTHubClient_t * pxAzureIoTHubClient,
-                                                                         AzureIoTHubClientCertificateSigningCallback_t xCallback,
-                                                                         void * prvCallbackContext,
-                                                                         uint32_t ulTimeoutMilliseconds )
+                                                                        AzureIoTHubClientCertificateSigningCallback_t xCallback,
+                                                                        void * prvCallbackContext,
+                                                                        uint32_t ulTimeoutMilliseconds )
 {
     AzureIoTMQTTSubscribeInfo_t xMqttSubscription = { 0 };
     AzureIoTMQTTResult_t xMQTTResult;
@@ -1598,13 +1598,13 @@ AzureIoTResult_t AzureIoTHubClient_UnsubscribeCertificateSigningResponse( AzureI
 /*-----------------------------------------------------------*/
 
 AzureIoTResult_t AzureIoTHubClient_SendCertificateSigningRequest( AzureIoTHubClient_t * pxAzureIoTHubClient,
-                                                                    const uint8_t * pucCSR,
-                                                                    uint32_t ulCSRLength,
-                                                                    const uint8_t * pucRequestID,
-                                                                    uint16_t usRequestIDLength,
-                                                                    const AzureIoTHubClientCertificateSigningRequestOptions_t * pxOptions,
-                                                                    uint8_t * pucPayloadBuffer,
-                                                                    uint32_t ulPayloadBufferLength )
+                                                                  const uint8_t * pucCSR,
+                                                                  uint32_t ulCSRLength,
+                                                                  const uint8_t * pucRequestID,
+                                                                  uint16_t usRequestIDLength,
+                                                                  const AzureIoTHubClientCertificateSigningRequestOptions_t * pxOptions,
+                                                                  uint8_t * pucPayloadBuffer,
+                                                                  uint32_t ulPayloadBufferLength )
 {
     AzureIoTMQTTResult_t xMQTTResult;
     AzureIoTResult_t xResult;
@@ -1691,9 +1691,8 @@ AzureIoTResult_t AzureIoTHubClient_SendCertificateSigningRequest( AzureIoTHubCli
 }
 /*-----------------------------------------------------------*/
 
-AzureIoTResult_t AzureIoTHubClient_GetIssuedCertificateChainLength(
-    AzureIoTHubClient_t * pxAzureIoTHubClient,
-    uint32_t * pulIssuedCertificateChainLength )
+AzureIoTResult_t AzureIoTHubClient_GetIssuedCertificateChainLength( AzureIoTHubClient_t * pxAzureIoTHubClient,
+                                                                    uint32_t * pulIssuedCertificateChainLength )
 {
     AzureIoTResult_t xResult;
 
@@ -1714,11 +1713,10 @@ AzureIoTResult_t AzureIoTHubClient_GetIssuedCertificateChainLength(
 }
 /*-----------------------------------------------------------*/
 
-AzureIoTResult_t AzureIoTHubClient_GetIssuedCertificate(
-    AzureIoTHubClient_t * pxAzureIoTHubClient,
-    uint32_t ulCertificatePositionNumber,
-    uint8_t * pucIssuedCertificate,
-    uint32_t * pulIssuedCertificateLength )
+AzureIoTResult_t AzureIoTHubClient_GetIssuedCertificate( AzureIoTHubClient_t * pxAzureIoTHubClient,
+                                                         uint32_t ulCertificatePositionNumber,
+                                                         uint8_t * pucIssuedCertificate,
+                                                         uint32_t * pulIssuedCertificateLength )
 {
     AzureIoTResult_t xResult;
     az_span * pxCertificate;
@@ -1739,7 +1737,7 @@ AzureIoTResult_t AzureIoTHubClient_GetIssuedCertificate(
     else
     {
         pxCertificate = &pxAzureIoTHubClient->_internal.xCSRCompletedResponse
-                             .issued_certificate_chain[ ulCertificatePositionNumber ];
+                           .issued_certificate_chain[ ulCertificatePositionNumber ];
         ulCertificateLength = ( uint32_t ) az_span_size( *pxCertificate );
 
         if( *pulIssuedCertificateLength < ulCertificateLength )

--- a/source/azure_iot_provisioning_client.c
+++ b/source/azure_iot_provisioning_client.c
@@ -12,6 +12,7 @@
 /* Kernel includes. */
 #include "FreeRTOS.h"
 #include "task.h"
+#include <inttypes.h>
 
 /* azure iot includes. */
 #include "azure_iot_mqtt.h"
@@ -310,9 +311,9 @@ static void prvProvClientRequest( AzureIoTProvisioningClient_t * pxAzureProvClie
             return;
         }
 
-        if ( pxAzureProvClient->_internal.ulCertificateSigningRequestLength > 0 )
+        if( pxAzureProvClient->_internal.ulCertificateSigningRequestLength > 0 )
         {
-            xRegisterOptions.certificate_signing_request = az_span_create( ( uint8_t * ) pxAzureProvClient->_internal.pucCertificateSigningRequest, ( int32_t ) pxAzureProvClient->_internal.ulCertificateSigningRequestLength);
+            xRegisterOptions.certificate_signing_request = az_span_create( ( uint8_t * ) pxAzureProvClient->_internal.pucCertificateSigningRequest, ( int32_t ) pxAzureProvClient->_internal.ulCertificateSigningRequestLength );
         }
 
         xMQTTPayloadLength = pxAzureProvClient->_internal.ulScratchBufferLength - ( uint32_t ) xMQTTTopicLength;
@@ -1022,8 +1023,8 @@ AzureIoTResult_t AzureIoTProvisioningClient_SetRegistrationPayload( AzureIoTProv
 /*-----------------------------------------------------------*/
 
 AzureIoTResult_t AzureIoTProvisioningClient_SetRegistrationCertificateSigningRequest( AzureIoTProvisioningClient_t * pxAzureProvClient,
-                                                                    const uint8_t * pucCertificateSigningRequest,
-                                                                    uint32_t ulCertificateSigningRequestLength )
+                                                                                      const uint8_t * pucCertificateSigningRequest,
+                                                                                      uint32_t ulCertificateSigningRequestLength )
 {
     AzureIoTResult_t xResult;
 
@@ -1050,7 +1051,7 @@ AzureIoTResult_t AzureIoTProvisioningClient_SetRegistrationCertificateSigningReq
 /*-----------------------------------------------------------*/
 
 AzureIoTResult_t AzureIoTProvisioningClient_GetIssuedCertificateChainLength( AzureIoTProvisioningClient_t * pxAzureProvClient,
-                                                             uint32_t * pulSignedCertificateChainLength )
+                                                                             uint32_t * pulSignedCertificateChainLength )
 {
     AzureIoTResult_t xResult;
 
@@ -1080,9 +1081,9 @@ AzureIoTResult_t AzureIoTProvisioningClient_GetIssuedCertificateChainLength( Azu
 /*-----------------------------------------------------------*/
 
 AzureIoTResult_t AzureIoTProvisioningClient_GetIssuedCertificate( AzureIoTProvisioningClient_t * pxAzureProvClient,
-                                                             uint32_t ulCertificatePositionNumber,
-                                                             uint8_t * pucIssuedCertificate,
-                                                             uint32_t * pulIssuedCertificateLength )
+                                                                  uint32_t ulCertificatePositionNumber,
+                                                                  uint8_t * pucIssuedCertificate,
+                                                                  uint32_t * pulIssuedCertificateLength )
 {
     AzureIoTResult_t xResult;
     uint32_t ulCertificateLength;
@@ -1110,12 +1111,12 @@ AzureIoTResult_t AzureIoTProvisioningClient_GetIssuedCertificate( AzureIoTProvis
     }
     else
     {
-        pxCertificate = &pxAzureProvClient->_internal.xRegisterResponse.registration_state.issued_certificate_chain[ulCertificatePositionNumber];
+        pxCertificate = &pxAzureProvClient->_internal.xRegisterResponse.registration_state.issued_certificate_chain[ ulCertificatePositionNumber ];
         ulCertificateLength = ( uint32_t ) az_span_size( *pxCertificate );
 
         if( ( *pulIssuedCertificateLength < ulCertificateLength ) )
         {
-            AZLogWarn( ( "AzureIoTProvisioningClient_GetIssuedCertificate failed: memory buffer passed (%d) is not enough to store certificate info (%d)", *pulIssuedCertificateLength,  ulCertificateLength ) );
+            AZLogWarn( ( "AzureIoTProvisioningClient_GetIssuedCertificate failed: memory buffer passed (%" PRIu32 ") is not enough to store certificate info (%" PRIu32 ")", *pulIssuedCertificateLength, ulCertificateLength ) );
             xResult = eAzureIoTErrorFailed;
         }
         else

--- a/source/include/azure_iot_hub_client.h
+++ b/source/include/azure_iot_hub_client.h
@@ -162,7 +162,7 @@ typedef struct AzureIoTHubClientCertificateSigningResponse
 {
     AzureIoTHubClientCertificateSigningResponseType_t xResponseType; /**< The type of response (accepted, completed, or error). */
 
-    AzureIoTHubMessageStatus_t xMessageStatus;                      /**< The HTTP-like status code (200, 202, 4xx, 5xx). */
+    AzureIoTHubMessageStatus_t xMessageStatus;                       /**< The HTTP-like status code (200, 202, 4xx, 5xx). */
 
     const void * pvMessagePayload;                                   /**< The pointer to the response payload. */
     uint32_t ulPayloadLength;                                        /**< The length of the response payload. */
@@ -176,10 +176,10 @@ typedef struct AzureIoTHubClientCertificateSigningResponse
  */
 typedef struct AzureIoTHubClientCertificateSigningRequestOptions
 {
-    const uint8_t * pucReplace;   /**< Optional replace field. Use "*" to replace any active request, or pass
-                                      a prior request ID (see #AzureIoTHubClient_SendCertificateSigningRequest
-                                      pucRequestID) to replace a specific one. */
-    uint16_t usReplaceLength;     /**< The length of the replace field. */
+    const uint8_t * pucReplace; /**< Optional replace field. Use "*" to replace any active request, or pass
+                                 *  a prior request ID (see #AzureIoTHubClient_SendCertificateSigningRequest
+                                 *  pucRequestID) to replace a specific one. */
+    uint16_t usReplaceLength;   /**< The length of the replace field. */
 } AzureIoTHubClientCertificateSigningRequestOptions_t;
 
 /**
@@ -218,7 +218,7 @@ typedef void ( * AzureIoTHubClientPropertiesCallback_t ) ( AzureIoTHubClientProp
  * @param[in] pvContext The context passed back to the caller.
  */
 typedef void ( * AzureIoTHubClientCertificateSigningCallback_t ) ( AzureIoTHubClientCertificateSigningResponse_t * pxResponse,
-                                                                    void * pvContext );
+                                                                   void * pvContext );
 
 /**
  * @brief Receive context to be used internally for the processing of messages.
@@ -560,9 +560,9 @@ AzureIoTResult_t AzureIoTHubClient_RequestPropertiesAsync( AzureIoTHubClient_t *
  * @return An #AzureIoTResult_t with the result of the operation.
  */
 AzureIoTResult_t AzureIoTHubClient_SubscribeCertificateSigningResponse( AzureIoTHubClient_t * pxAzureIoTHubClient,
-                                                                         AzureIoTHubClientCertificateSigningCallback_t xCSRCallback,
-                                                                         void * prvCallbackContext,
-                                                                         uint32_t ulTimeoutMilliseconds );
+                                                                        AzureIoTHubClientCertificateSigningCallback_t xCSRCallback,
+                                                                        void * prvCallbackContext,
+                                                                        uint32_t ulTimeoutMilliseconds );
 
 /**
  * @brief Unsubscribe from certificate signing responses.
@@ -593,13 +593,13 @@ AzureIoTResult_t AzureIoTHubClient_UnsubscribeCertificateSigningResponse( AzureI
  * @return An #AzureIoTResult_t with the result of the operation.
  */
 AzureIoTResult_t AzureIoTHubClient_SendCertificateSigningRequest( AzureIoTHubClient_t * pxAzureIoTHubClient,
-                                                                    const uint8_t * pucCSR,
-                                                                    uint32_t ulCSRLength,
-                                                                    const uint8_t * pucRequestID,
-                                                                    uint16_t usRequestIDLength,
-                                                                    const AzureIoTHubClientCertificateSigningRequestOptions_t * pxOptions,
-                                                                    uint8_t * pucPayloadBuffer,
-                                                                    uint32_t ulPayloadBufferLength );
+                                                                  const uint8_t * pucCSR,
+                                                                  uint32_t ulCSRLength,
+                                                                  const uint8_t * pucRequestID,
+                                                                  uint16_t usRequestIDLength,
+                                                                  const AzureIoTHubClientCertificateSigningRequestOptions_t * pxOptions,
+                                                                  uint8_t * pucPayloadBuffer,
+                                                                  uint32_t ulPayloadBufferLength );
 
 /**
  * @brief Get the number of certificates in the issued certificate chain from the last CSR response.
@@ -612,9 +612,8 @@ AzureIoTResult_t AzureIoTHubClient_SendCertificateSigningRequest( AzureIoTHubCli
  *             with the number of issued certificates.
  * @return An #AzureIoTResult_t with the result of the operation.
  */
-AzureIoTResult_t AzureIoTHubClient_GetIssuedCertificateChainLength(
-    AzureIoTHubClient_t * pxAzureIoTHubClient,
-    uint32_t * pulIssuedCertificateChainLength );
+AzureIoTResult_t AzureIoTHubClient_GetIssuedCertificateChainLength( AzureIoTHubClient_t * pxAzureIoTHubClient,
+                                                                    uint32_t * pulIssuedCertificateChainLength );
 
 /**
  * @brief Get a certificate from the issued certificate chain at the given position.
@@ -632,11 +631,10 @@ AzureIoTResult_t AzureIoTHubClient_GetIssuedCertificateChainLength(
  *                On output, the length of the certificate data written.
  * @return An #AzureIoTResult_t with the result of the operation.
  */
-AzureIoTResult_t AzureIoTHubClient_GetIssuedCertificate(
-    AzureIoTHubClient_t * pxAzureIoTHubClient,
-    uint32_t ulCertificatePositionNumber,
-    uint8_t * pucIssuedCertificate,
-    uint32_t * pulIssuedCertificateLength );
+AzureIoTResult_t AzureIoTHubClient_GetIssuedCertificate( AzureIoTHubClient_t * pxAzureIoTHubClient,
+                                                         uint32_t ulCertificatePositionNumber,
+                                                         uint8_t * pucIssuedCertificate,
+                                                         uint32_t * pulIssuedCertificateLength );
 
 #include "azure/core/_az_cfg_suffix.h"
 

--- a/source/include/azure_iot_provisioning_client.h
+++ b/source/include/azure_iot_provisioning_client.h
@@ -223,10 +223,10 @@ AzureIoTResult_t AzureIoTProvisioningClient_SetRegistrationPayload( AzureIoTProv
  * @param[in] pucCertificateSigningRequest A pointer to the certificate data.
  * @param[in] ulCertificateSigningRequestLength Length of `CertificateSigningRequest`. Does not include the `NULL` terminator.
  * @return An #AzureIoTResult_t with the result of the operation.
- */                                                                 
+ */
 AzureIoTResult_t AzureIoTProvisioningClient_SetRegistrationCertificateSigningRequest( AzureIoTProvisioningClient_t * pxAzureProvClient,
-                                                                    const uint8_t * pucCertificateSigningRequest,
-                                                                    uint32_t ulCertificateSigningRequestLength );
+                                                                                      const uint8_t * pucCertificateSigningRequest,
+                                                                                      uint32_t ulCertificateSigningRequestLength );
 
 /**
  * @brief After a registration has been completed, get the number of certificates issued for the certificate signing request.
@@ -236,7 +236,7 @@ AzureIoTResult_t AzureIoTProvisioningClient_SetRegistrationCertificateSigningReq
  * @return An #AzureIoTResult_t with the result of the operation.
  */
 AzureIoTResult_t AzureIoTProvisioningClient_GetIssuedCertificateChainLength( AzureIoTProvisioningClient_t * pxAzureProvClient,
-                                                             uint32_t * pulSignedCertificateChainLength );
+                                                                             uint32_t * pulSignedCertificateChainLength );
 
 /**
  * @brief After a registration has been completed, get the certificates issued for the certificate signing request.
@@ -248,9 +248,9 @@ AzureIoTResult_t AzureIoTProvisioningClient_GetIssuedCertificateChainLength( Azu
  * @return An #AzureIoTResult_t with the result of the operation.
  */
 AzureIoTResult_t AzureIoTProvisioningClient_GetIssuedCertificate( AzureIoTProvisioningClient_t * pxAzureProvClient,
-                                                             uint32_t ulCertificatePositionNumber,
-                                                             uint8_t * pucIssuedCertificate,
-                                                             uint32_t * pulIssuedCertificateLength );
+                                                                  uint32_t ulCertificatePositionNumber,
+                                                                  uint8_t * pucIssuedCertificate,
+                                                                  uint32_t * pulIssuedCertificateLength );
 
 #include "azure/core/_az_cfg_suffix.h"
 

--- a/tests/ut/azure_iot_hub_client_csr_ut.c
+++ b/tests/ut/azure_iot_hub_client_csr_ut.c
@@ -14,16 +14,16 @@
 #include "azure_iot_hub_client.h"
 /*-----------------------------------------------------------*/
 
-#define testCSR_CALLBACK_ID                         ( 4 )
-#define testCSR_ACCEPTED_MESSAGE_TOPIC              "$iothub/credentials/res/202/?$rid=1"
-#define testCSR_COMPLETED_MESSAGE_TOPIC             "$iothub/credentials/res/200/?$rid=1"
-#define testCSR_ERROR_MESSAGE_TOPIC                 "$iothub/credentials/res/400/?$rid=1"
-#define testCSR_ACCEPTED_PAYLOAD                    "{\"correlationId\":\"test-corr-id\",\"operationExpires\":\"2025-06-09T17:31:31.426Z\"}"
-#define testCSR_COMPLETED_PAYLOAD                   "[\"ROOT CERT\",\"INTERMEDIATE CERT\",\"LEAF CERT\"]"
-#define testCSR_ERROR_PAYLOAD                       "{\"errorCode\":400040,\"message\":\"Credential management operation failed\"}"
-#define testCSR_DATA                                "MIICYTCCAUkCAQAwHDEaMBgGA1wRZGAw"
-#define testCSR_REQUEST_ID                          "1"
-#define testEMPTY_JSON                              "{}"
+#define testCSR_CALLBACK_ID                ( 4 )
+#define testCSR_ACCEPTED_MESSAGE_TOPIC     "$iothub/credentials/res/202/?$rid=1"
+#define testCSR_COMPLETED_MESSAGE_TOPIC    "$iothub/credentials/res/200/?$rid=1"
+#define testCSR_ERROR_MESSAGE_TOPIC        "$iothub/credentials/res/400/?$rid=1"
+#define testCSR_ACCEPTED_PAYLOAD           "{\"correlationId\":\"test-corr-id\",\"operationExpires\":\"2025-06-09T17:31:31.426Z\"}"
+#define testCSR_COMPLETED_PAYLOAD          "[\"ROOT CERT\",\"INTERMEDIATE CERT\",\"LEAF CERT\"]"
+#define testCSR_ERROR_PAYLOAD              "{\"errorCode\":400040,\"message\":\"Credential management operation failed\"}"
+#define testCSR_DATA                       "MIICYTCCAUkCAQAwHDEaMBgGA1wRZGAw"
+#define testCSR_REQUEST_ID                 "1"
+#define testEMPTY_JSON                     "{}"
 /*-----------------------------------------------------------*/
 
 /* Data exported by cmocka port for MQTT */
@@ -86,7 +86,7 @@ static void prvSetupTestIoTHubClient( AzureIoTHubClient_t * pxTestIoTHubClient )
 /*-----------------------------------------------------------*/
 
 static void prvTestCSRCallback( AzureIoTHubClientCertificateSigningResponse_t * pxResponse,
-                                 void * pvContext )
+                                void * pvContext )
 {
     assert_true( pxResponse != NULL );
     assert_true( pvContext == NULL );
@@ -109,8 +109,8 @@ static void prvSubscribeToCSR( AzureIoTHubClient_t * pxTestIoTHubClient )
     xDeserializedInfo.usPacketIdentifier = usTestPacketId;
     ulDelayReceivePacket = 0;
     assert_int_equal( AzureIoTHubClient_SubscribeCertificateSigningResponse( pxTestIoTHubClient,
-                                                                              prvTestCSRCallback,
-                                                                              NULL, ( uint32_t ) -1 ),
+                                                                             prvTestCSRCallback,
+                                                                             NULL, ( uint32_t ) -1 ),
                       eAzureIoTSuccess );
 }
 /*-----------------------------------------------------------*/
@@ -125,14 +125,14 @@ static void testAzureIoTHubClient_SubscribeCSR_InvalidArgFailure( void ** ppvSta
 
     /* Fail subscribe when client is NULL */
     assert_int_equal( AzureIoTHubClient_SubscribeCertificateSigningResponse( NULL,
-                                                                              prvTestCSRCallback,
-                                                                              NULL, ( uint32_t ) -1 ),
+                                                                             prvTestCSRCallback,
+                                                                             NULL, ( uint32_t ) -1 ),
                       eAzureIoTErrorInvalidArgument );
 
     /* Fail subscribe when callback is NULL */
     assert_int_equal( AzureIoTHubClient_SubscribeCertificateSigningResponse( &xTestIoTHubClient,
-                                                                              NULL,
-                                                                              NULL, ( uint32_t ) -1 ),
+                                                                             NULL,
+                                                                             NULL, ( uint32_t ) -1 ),
                       eAzureIoTErrorInvalidArgument );
 }
 /*-----------------------------------------------------------*/
@@ -147,8 +147,8 @@ static void testAzureIoTHubClient_SubscribeCSR_SubscribeFailure( void ** ppvStat
 
     will_return( AzureIoTMQTT_Subscribe, eAzureIoTMQTTSendFailed );
     assert_int_equal( AzureIoTHubClient_SubscribeCertificateSigningResponse( &xTestIoTHubClient,
-                                                                              prvTestCSRCallback,
-                                                                              NULL, ( uint32_t ) -1 ),
+                                                                             prvTestCSRCallback,
+                                                                             NULL, ( uint32_t ) -1 ),
                       eAzureIoTErrorSubscribeFailed );
 }
 /*-----------------------------------------------------------*/
@@ -164,8 +164,8 @@ static void testAzureIoTHubClient_SubscribeCSR_ReceiveFailure( void ** ppvState 
     will_return( AzureIoTMQTT_Subscribe, eAzureIoTMQTTSuccess );
     will_return( AzureIoTMQTT_ProcessLoop, eAzureIoTMQTTRecvFailed );
     assert_int_equal( AzureIoTHubClient_SubscribeCertificateSigningResponse( &xTestIoTHubClient,
-                                                                              prvTestCSRCallback,
-                                                                              NULL, ( uint32_t ) -1 ),
+                                                                             prvTestCSRCallback,
+                                                                             NULL, ( uint32_t ) -1 ),
                       eAzureIoTErrorFailed );
 }
 /*-----------------------------------------------------------*/
@@ -183,8 +183,8 @@ static void testAzureIoTHubClient_SubscribeCSR_Success( void ** ppvState )
     xPacketInfo.ucType = azureiotmqttPACKET_TYPE_SUBACK;
     xDeserializedInfo.usPacketIdentifier = usTestPacketId;
     assert_int_equal( AzureIoTHubClient_SubscribeCertificateSigningResponse( &xTestIoTHubClient,
-                                                                              prvTestCSRCallback,
-                                                                              NULL, ( uint32_t ) -1 ),
+                                                                             prvTestCSRCallback,
+                                                                             NULL, ( uint32_t ) -1 ),
                       eAzureIoTSuccess );
 }
 /*-----------------------------------------------------------*/
@@ -203,8 +203,8 @@ static void testAzureIoTHubClient_SubscribeCSR_DelayedSuccess( void ** ppvState 
     xDeserializedInfo.usPacketIdentifier = usTestPacketId;
     ulDelayReceivePacket = 5 * azureiotconfigSUBACK_WAIT_INTERVAL_MS;
     assert_int_equal( AzureIoTHubClient_SubscribeCertificateSigningResponse( &xTestIoTHubClient,
-                                                                              prvTestCSRCallback,
-                                                                              NULL, ( uint32_t ) -1 ),
+                                                                             prvTestCSRCallback,
+                                                                             NULL, ( uint32_t ) -1 ),
                       eAzureIoTSuccess );
 }
 /*-----------------------------------------------------------*/
@@ -225,8 +225,8 @@ static void testAzureIoTHubClient_SubscribeCSR_MultipleSuccess( void ** ppvState
         xDeserializedInfo.usPacketIdentifier = usTestPacketId;
         ulDelayReceivePacket = 0;
         assert_int_equal( AzureIoTHubClient_SubscribeCertificateSigningResponse( &xTestIoTHubClient,
-                                                                                  prvTestCSRCallback,
-                                                                                  NULL, ( uint32_t ) -1 ),
+                                                                                 prvTestCSRCallback,
+                                                                                 NULL, ( uint32_t ) -1 ),
                           eAzureIoTSuccess );
     }
 }
@@ -298,40 +298,40 @@ static void testAzureIoTHubClient_SendCSR_InvalidArgFailure( void ** ppvState )
 
     /* Fail when client is NULL */
     assert_int_equal( AzureIoTHubClient_SendCertificateSigningRequest( NULL,
-                                                                        ( const uint8_t * ) testCSR_DATA,
-                                                                        sizeof( testCSR_DATA ) - 1,
-                                                                        ( const uint8_t * ) testCSR_REQUEST_ID,
-                                                                        sizeof( testCSR_REQUEST_ID ) - 1,
-                                                                        NULL,
-                                                                        ucPayloadBuffer, sizeof( ucPayloadBuffer ) ),
+                                                                       ( const uint8_t * ) testCSR_DATA,
+                                                                       sizeof( testCSR_DATA ) - 1,
+                                                                       ( const uint8_t * ) testCSR_REQUEST_ID,
+                                                                       sizeof( testCSR_REQUEST_ID ) - 1,
+                                                                       NULL,
+                                                                       ucPayloadBuffer, sizeof( ucPayloadBuffer ) ),
                       eAzureIoTErrorInvalidArgument );
 
     /* Fail when CSR is NULL */
     assert_int_equal( AzureIoTHubClient_SendCertificateSigningRequest( &xTestIoTHubClient,
-                                                                        NULL, 0,
-                                                                        ( const uint8_t * ) testCSR_REQUEST_ID,
-                                                                        sizeof( testCSR_REQUEST_ID ) - 1,
-                                                                        NULL,
-                                                                        ucPayloadBuffer, sizeof( ucPayloadBuffer ) ),
+                                                                       NULL, 0,
+                                                                       ( const uint8_t * ) testCSR_REQUEST_ID,
+                                                                       sizeof( testCSR_REQUEST_ID ) - 1,
+                                                                       NULL,
+                                                                       ucPayloadBuffer, sizeof( ucPayloadBuffer ) ),
                       eAzureIoTErrorInvalidArgument );
 
     /* Fail when request ID is NULL */
     assert_int_equal( AzureIoTHubClient_SendCertificateSigningRequest( &xTestIoTHubClient,
-                                                                        ( const uint8_t * ) testCSR_DATA,
-                                                                        sizeof( testCSR_DATA ) - 1,
-                                                                        NULL, 0,
-                                                                        NULL,
-                                                                        ucPayloadBuffer, sizeof( ucPayloadBuffer ) ),
+                                                                       ( const uint8_t * ) testCSR_DATA,
+                                                                       sizeof( testCSR_DATA ) - 1,
+                                                                       NULL, 0,
+                                                                       NULL,
+                                                                       ucPayloadBuffer, sizeof( ucPayloadBuffer ) ),
                       eAzureIoTErrorInvalidArgument );
 
     /* Fail when payload buffer is NULL */
     assert_int_equal( AzureIoTHubClient_SendCertificateSigningRequest( &xTestIoTHubClient,
-                                                                        ( const uint8_t * ) testCSR_DATA,
-                                                                        sizeof( testCSR_DATA ) - 1,
-                                                                        ( const uint8_t * ) testCSR_REQUEST_ID,
-                                                                        sizeof( testCSR_REQUEST_ID ) - 1,
-                                                                        NULL,
-                                                                        NULL, 0 ),
+                                                                       ( const uint8_t * ) testCSR_DATA,
+                                                                       sizeof( testCSR_DATA ) - 1,
+                                                                       ( const uint8_t * ) testCSR_REQUEST_ID,
+                                                                       sizeof( testCSR_REQUEST_ID ) - 1,
+                                                                       NULL,
+                                                                       NULL, 0 ),
                       eAzureIoTErrorInvalidArgument );
 }
 /*-----------------------------------------------------------*/
@@ -346,12 +346,12 @@ static void testAzureIoTHubClient_SendCSR_NotSubscribedFailure( void ** ppvState
 
     /* Send without subscribing first */
     assert_int_equal( AzureIoTHubClient_SendCertificateSigningRequest( &xTestIoTHubClient,
-                                                                        ( const uint8_t * ) testCSR_DATA,
-                                                                        sizeof( testCSR_DATA ) - 1,
-                                                                        ( const uint8_t * ) testCSR_REQUEST_ID,
-                                                                        sizeof( testCSR_REQUEST_ID ) - 1,
-                                                                        NULL,
-                                                                        ucPayloadBuffer, sizeof( ucPayloadBuffer ) ),
+                                                                       ( const uint8_t * ) testCSR_DATA,
+                                                                       sizeof( testCSR_DATA ) - 1,
+                                                                       ( const uint8_t * ) testCSR_REQUEST_ID,
+                                                                       sizeof( testCSR_REQUEST_ID ) - 1,
+                                                                       NULL,
+                                                                       ucPayloadBuffer, sizeof( ucPayloadBuffer ) ),
                       eAzureIoTErrorTopicNotSubscribed );
 }
 /*-----------------------------------------------------------*/
@@ -367,12 +367,12 @@ static void testAzureIoTHubClient_SendCSR_PublishFailure( void ** ppvState )
 
     will_return( AzureIoTMQTT_Publish, eAzureIoTMQTTSendFailed );
     assert_int_equal( AzureIoTHubClient_SendCertificateSigningRequest( &xTestIoTHubClient,
-                                                                        ( const uint8_t * ) testCSR_DATA,
-                                                                        sizeof( testCSR_DATA ) - 1,
-                                                                        ( const uint8_t * ) testCSR_REQUEST_ID,
-                                                                        sizeof( testCSR_REQUEST_ID ) - 1,
-                                                                        NULL,
-                                                                        ucPayloadBuffer, sizeof( ucPayloadBuffer ) ),
+                                                                       ( const uint8_t * ) testCSR_DATA,
+                                                                       sizeof( testCSR_DATA ) - 1,
+                                                                       ( const uint8_t * ) testCSR_REQUEST_ID,
+                                                                       sizeof( testCSR_REQUEST_ID ) - 1,
+                                                                       NULL,
+                                                                       ucPayloadBuffer, sizeof( ucPayloadBuffer ) ),
                       eAzureIoTErrorPublishFailed );
 }
 /*-----------------------------------------------------------*/
@@ -389,12 +389,12 @@ static void testAzureIoTHubClient_SendCSR_Success( void ** ppvState )
     will_return( AzureIoTMQTT_Publish, eAzureIoTMQTTSuccess );
     usSentQOS = eAzureIoTMQTTQoS1;
     assert_int_equal( AzureIoTHubClient_SendCertificateSigningRequest( &xTestIoTHubClient,
-                                                                        ( const uint8_t * ) testCSR_DATA,
-                                                                        sizeof( testCSR_DATA ) - 1,
-                                                                        ( const uint8_t * ) testCSR_REQUEST_ID,
-                                                                        sizeof( testCSR_REQUEST_ID ) - 1,
-                                                                        NULL,
-                                                                        ucPayloadBuffer, sizeof( ucPayloadBuffer ) ),
+                                                                       ( const uint8_t * ) testCSR_DATA,
+                                                                       sizeof( testCSR_DATA ) - 1,
+                                                                       ( const uint8_t * ) testCSR_REQUEST_ID,
+                                                                       sizeof( testCSR_REQUEST_ID ) - 1,
+                                                                       NULL,
+                                                                       ucPayloadBuffer, sizeof( ucPayloadBuffer ) ),
                       eAzureIoTSuccess );
 }
 /*-----------------------------------------------------------*/
@@ -537,7 +537,7 @@ static void testAzureIoTHubClient_SendCSR_WithReplaceOption_Success( void ** ppv
     AzureIoTHubClient_t xTestIoTHubClient;
     AzureIoTHubClientCertificateSigningRequestOptions_t xOptions =
     {
-        .pucReplace    = ( const uint8_t * ) "*",
+        .pucReplace      = ( const uint8_t * ) "*",
         .usReplaceLength = sizeof( "*" ) - 1
     };
 
@@ -549,12 +549,12 @@ static void testAzureIoTHubClient_SendCSR_WithReplaceOption_Success( void ** ppv
     will_return( AzureIoTMQTT_Publish, eAzureIoTMQTTSuccess );
     usSentQOS = eAzureIoTMQTTQoS1;
     assert_int_equal( AzureIoTHubClient_SendCertificateSigningRequest( &xTestIoTHubClient,
-                                                                        ( const uint8_t * ) testCSR_DATA,
-                                                                        sizeof( testCSR_DATA ) - 1,
-                                                                        ( const uint8_t * ) testCSR_REQUEST_ID,
-                                                                        sizeof( testCSR_REQUEST_ID ) - 1,
-                                                                        &xOptions,
-                                                                        ucPayloadBuffer, sizeof( ucPayloadBuffer ) ),
+                                                                       ( const uint8_t * ) testCSR_DATA,
+                                                                       sizeof( testCSR_DATA ) - 1,
+                                                                       ( const uint8_t * ) testCSR_REQUEST_ID,
+                                                                       sizeof( testCSR_REQUEST_ID ) - 1,
+                                                                       &xOptions,
+                                                                       ucPayloadBuffer, sizeof( ucPayloadBuffer ) ),
                       eAzureIoTSuccess );
 }
 /*-----------------------------------------------------------*/
@@ -575,12 +575,12 @@ static void testAzureIoTHubClient_SendCSR_AfterUnsubscribe_Failure( void ** ppvS
 
     /* After unsubscribing, send must fail with topic-not-subscribed */
     assert_int_equal( AzureIoTHubClient_SendCertificateSigningRequest( &xTestIoTHubClient,
-                                                                        ( const uint8_t * ) testCSR_DATA,
-                                                                        sizeof( testCSR_DATA ) - 1,
-                                                                        ( const uint8_t * ) testCSR_REQUEST_ID,
-                                                                        sizeof( testCSR_REQUEST_ID ) - 1,
-                                                                        NULL,
-                                                                        ucPayloadBuffer, sizeof( ucPayloadBuffer ) ),
+                                                                       ( const uint8_t * ) testCSR_DATA,
+                                                                       sizeof( testCSR_DATA ) - 1,
+                                                                       ( const uint8_t * ) testCSR_REQUEST_ID,
+                                                                       sizeof( testCSR_REQUEST_ID ) - 1,
+                                                                       NULL,
+                                                                       ucPayloadBuffer, sizeof( ucPayloadBuffer ) ),
                       eAzureIoTErrorTopicNotSubscribed );
 }
 /*-----------------------------------------------------------*/
@@ -611,8 +611,8 @@ static void testAzureIoTHubClient_SubscribeCSR_WithContext_Success( void ** ppvS
     xDeserializedInfo.usPacketIdentifier = usTestPacketId;
     ulDelayReceivePacket = 0;
     assert_int_equal( AzureIoTHubClient_SubscribeCertificateSigningResponse( &xTestIoTHubClient,
-                                                                              prvTestCSRCallbackWithContext,
-                                                                              &ulTestContextValue, ( uint32_t ) -1 ),
+                                                                             prvTestCSRCallbackWithContext,
+                                                                             &ulTestContextValue, ( uint32_t ) -1 ),
                       eAzureIoTSuccess );
 }
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the Azure IoT client codebase, mainly focusing on code style consistency, logging improvements, and minor documentation adjustments. The most notable changes are grouped by theme below.

**Code Style and Consistency:**

* Refactored the function signatures for `AzureIoTHubClient_GetIssuedCertificateChainLength` and `AzureIoTHubClient_GetIssuedCertificate` in both `azure_iot_hub_client.c` and `azure_iot_hub_client.h` to use a single-line style for arguments, improving readability and consistency across the codebase. [[1]](diffhunk://#diff-9851b36fad051943e3ad848d9b1c02a2b3dda336f8214ac9b1271f060f7910ecL1694-R1694) [[2]](diffhunk://#diff-9851b36fad051943e3ad848d9b1c02a2b3dda336f8214ac9b1271f060f7910ecL1717-R1716) [[3]](diffhunk://#diff-0e120e10ebcb56142778d40f007593574f2c64097e828097586b4377b078092aL615-R615) [[4]](diffhunk://#diff-0e120e10ebcb56142778d40f007593574f2c64097e828097586b4377b078092aL635-R634)

**Logging and Diagnostics:**

* Improved logging in `AzureIoTProvisioningClient_GetIssuedCertificate` by switching to the portable `PRIu32` format specifier for `uint32_t` values, ensuring correct output across platforms.

**Documentation and Comments:**

* Fixed the alignment and formatting of the comment for the `pucReplace` field in the `AzureIoTHubClientCertificateSigningRequestOptions` struct to improve clarity.

**Dependencies:**

* Updated the `azure-sdk-for-c` submodule to a newer commit, bringing in upstream changes and potential bug fixes or features.

**Build/Portability:**

* Added the `<inttypes.h>` header to `azure_iot_provisioning_client.c` to support portable integer formatting macros.